### PR TITLE
ci: add lint and format checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,9 @@ jobs:
 
       - name: Test
         run: cmake --build build --target check-warpforth
+
+      - name: Check C++ formatting
+        run: cmake --build build --target check-format
+
+      - name: Ruff check
+        run: uv run ruff check gpu_test/ && uv run ruff format --check gpu_test/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,8 @@ else()
 endif()
 
 # Add format target to run clang-format on all source files
-find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format)
+find_program(CLANG_FORMAT_EXECUTABLE
+  NAMES clang-format-${LLVM_VERSION_MAJOR} clang-format)
 if(CLANG_FORMAT_EXECUTABLE)
   file(GLOB_RECURSE ALL_SOURCE_FILES
     ${PROJECT_SOURCE_DIR}/include/**/*.h
@@ -56,6 +57,11 @@ if(CLANG_FORMAT_EXECUTABLE)
   add_custom_target(format
     COMMAND ${CLANG_FORMAT_EXECUTABLE} -i ${ALL_SOURCE_FILES}
     COMMENT "Running clang-format on all source files"
+    VERBATIM
+  )
+  add_custom_target(check-format
+    COMMAND ${CLANG_FORMAT_EXECUTABLE} --dry-run --Werror ${ALL_SOURCE_FILES}
+    COMMENT "Checking clang-format on all source files"
     VERBATIM
   )
 endif()


### PR DESCRIPTION
## Summary
- Add `check-format` CMake target that runs `clang-format --dry-run --Werror`
- Search for versioned clang-format binary (e.g. `clang-format-20`) on Ubuntu
- Add Ruff lint and format check step for Python code

## Test plan
- [x] `cmake --build build --target check-format` passes locally
- [x] CI pipeline passes on this PR