### PR TITLE
feat: add NIP, TUCK, PICK, ROLL stack operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ uv run ruff format gpu_test/
 
 - **Stack Type**: `!forth.stack` - untyped stack, programmer ensures type safety
 - **Operations**: All take stack as input and produce stack as output (except `forth.stack`)
-- **Supported Words**: literals, `DUP DROP SWAP OVER ROT`, `+ - * / MOD`, `= < > 0=`, `@ !`, `CELLS`, `IF ELSE THEN`, `BEGIN UNTIL`, `DO LOOP I`, `TID-X/Y/Z BID-X/Y/Z BDIM-X/Y/Z GDIM-X/Y/Z GLOBAL-ID` (GPU indexing).
+- **Supported Words**: literals, `DUP DROP SWAP OVER ROT NIP TUCK PICK ROLL`, `+ - * / MOD`, `AND OR XOR NOT LSHIFT RSHIFT`, `= < > 0=`, `@ !`, `CELLS`, `IF ELSE THEN`, `BEGIN UNTIL`, `DO LOOP I`, `TID-X/Y/Z BID-X/Y/Z BDIM-X/Y/Z GDIM-X/Y/Z GLOBAL-ID` (GPU indexing).
 - **Kernel Parameters**: Declared with `PARAM <name> <size>`, each becomes a `memref<Nxi64>` function argument with `forth.param_name` attribute. Using a param name in code pushes its byte address onto the stack via `forth.param_ref`
 - **Conversion**: `!forth.stack` → `memref<256xi64>` with explicit stack pointer
 - **GPU**: Functions wrapped in `gpu.module`, `main` gets `gpu.kernel` attribute, configured with bare pointers for NVVM conversion

--- a/include/warpforth/Dialect/Forth/ForthOps.td
+++ b/include/warpforth/Dialect/Forth/ForthOps.td
@@ -103,6 +103,67 @@ def Forth_RotOp : Forth_Op<"rot", [Pure]> {
   }];
 }
 
+def Forth_NipOp : Forth_Op<"nip", [Pure]> {
+  let summary = "Remove second stack element";
+  let description = [{
+    Removes the second element from the stack, keeping the top.
+    Forth semantics: ( a b -- b )
+  }];
+
+  let arguments = (ins Forth_StackType:$input_stack);
+  let results = (outs Forth_StackType:$output_stack);
+
+  let assemblyFormat = [{
+    $input_stack attr-dict `:` type($input_stack) `->` type($output_stack)
+  }];
+}
+
+def Forth_TuckOp : Forth_Op<"tuck", [Pure]> {
+  let summary = "Copy top element before second";
+  let description = [{
+    Copies the top element and inserts it before the second element.
+    Forth semantics: ( a b -- b a b )
+  }];
+
+  let arguments = (ins Forth_StackType:$input_stack);
+  let results = (outs Forth_StackType:$output_stack);
+
+  let assemblyFormat = [{
+    $input_stack attr-dict `:` type($input_stack) `->` type($output_stack)
+  }];
+}
+
+def Forth_PickOp : Forth_Op<"pick", [Pure]> {
+  let summary = "Copy nth element to top";
+  let description = [{
+    Pops n from the stack, then copies the nth element to the top.
+    Forth semantics: ( xn ... x0 n -- xn ... x0 xn )
+  }];
+
+  let arguments = (ins Forth_StackType:$input_stack);
+  let results = (outs Forth_StackType:$output_stack);
+
+  let assemblyFormat = [{
+    $input_stack attr-dict `:` type($input_stack) `->` type($output_stack)
+  }];
+}
+
+def Forth_RollOp : Forth_Op<"roll", [Pure]> {
+  let summary = "Rotate nth element to top";
+  let description = [{
+    Pops n from the stack, then rotates the nth element to the top,
+    shifting elements above it down.
+    Forth semantics: ( xn ... x0 n -- xn-1 ... x0 xn )
+  }];
+
+  let arguments = (ins Forth_StackType:$input_stack);
+  let results = (outs Forth_StackType:$output_stack);
+
+  let assemblyFormat = [{
+    $input_stack attr-dict `:` type($input_stack) `->` type($output_stack)
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Literal operations.
 //===----------------------------------------------------------------------===//

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
@@ -261,6 +261,17 @@ Value ForthParser::emitOperation(StringRef word, Value inputStack,
         .getResult();
   } else if (word == "ROT") {
     return builder.create<forth::RotOp>(loc, stackType, inputStack).getResult();
+  } else if (word == "NIP") {
+    return builder.create<forth::NipOp>(loc, stackType, inputStack).getResult();
+  } else if (word == "TUCK") {
+    return builder.create<forth::TuckOp>(loc, stackType, inputStack)
+        .getResult();
+  } else if (word == "PICK") {
+    return builder.create<forth::PickOp>(loc, stackType, inputStack)
+        .getResult();
+  } else if (word == "ROLL") {
+    return builder.create<forth::RollOp>(loc, stackType, inputStack)
+        .getResult();
   } else if (word == "+" || word == "ADD") {
     return builder.create<forth::AddOp>(loc, stackType, inputStack).getResult();
   } else if (word == "-" || word == "SUB") {

--- a/test/Conversion/ForthToMemRef/stack-manipulation.mlir
+++ b/test/Conversion/ForthToMemRef/stack-manipulation.mlir
@@ -33,6 +33,40 @@
 // CHECK: memref.store %[[ROT_C]], %{{.*}}[%[[ROT_SP1]]] : memref<256xi64>
 // CHECK: memref.store %[[ROT_A]], %{{.*}}[%[[ROT_SP]]] : memref<256xi64>
 
+// nip: load top, subi SP, store at SP-1 (a b -- b)
+// CHECK: %[[NIP_B:.*]] = memref.load %{{.*}}[%{{.*}}] : memref<256xi64>
+// CHECK: %[[NIP_SP1:.*]] = arith.subi
+// CHECK: memref.store %[[NIP_B]], %{{.*}}[%[[NIP_SP1]]] : memref<256xi64>
+
+// tuck: load b and a, store b/a/b (a b -- b a b)
+// CHECK: %[[TUCK_B:.*]] = memref.load %{{.*}}[%[[TUCK_SP:.*]]] : memref<256xi64>
+// CHECK: %[[TUCK_SP1:.*]] = arith.subi
+// CHECK: %[[TUCK_A:.*]] = memref.load %{{.*}}[%[[TUCK_SP1]]] : memref<256xi64>
+// CHECK: memref.store %[[TUCK_B]], %{{.*}}[%[[TUCK_SP1]]] : memref<256xi64>
+// CHECK: memref.store %[[TUCK_A]], %{{.*}}[%[[TUCK_SP]]] : memref<256xi64>
+// CHECK: %[[TUCK_NSP:.*]] = arith.addi
+// CHECK: memref.store %[[TUCK_B]], %{{.*}}[%[[TUCK_NSP]]] : memref<256xi64>
+
+// pick: load n, index_cast, subi (dynamic), load picked, store
+// CHECK: %[[PICK_N:.*]] = memref.load %{{.*}}[%{{.*}}] : memref<256xi64>
+// CHECK: %[[PICK_SP1:.*]] = arith.subi
+// CHECK: %[[PICK_NIDX:.*]] = arith.index_cast %[[PICK_N]]
+// CHECK: %[[PICK_ADDR:.*]] = arith.subi %[[PICK_SP1]], %[[PICK_NIDX]]
+// CHECK: %[[PICK_VAL:.*]] = memref.load %{{.*}}[%[[PICK_ADDR]]] : memref<256xi64>
+// CHECK: memref.store %[[PICK_VAL]]
+
+// roll: load n, index_cast, subi (dynamic), load saved, scf.for with load/store, store saved
+// CHECK: %[[ROLL_N:.*]] = memref.load %{{.*}}[%{{.*}}] : memref<256xi64>
+// CHECK: %[[ROLL_SP1:.*]] = arith.subi
+// CHECK: %[[ROLL_NIDX:.*]] = arith.index_cast %[[ROLL_N]]
+// CHECK: %[[ROLL_ADDR:.*]] = arith.subi %[[ROLL_SP1]], %[[ROLL_NIDX]]
+// CHECK: %[[ROLL_SAVED:.*]] = memref.load %{{.*}}[%[[ROLL_ADDR]]] : memref<256xi64>
+// CHECK: scf.for %[[ROLL_IV:.*]] = %[[ROLL_ADDR]] to %[[ROLL_SP1]]
+// CHECK:   %[[ROLL_NEXT:.*]] = arith.addi %[[ROLL_IV]]
+// CHECK:   %[[ROLL_SHIFTED:.*]] = memref.load %{{.*}}[%[[ROLL_NEXT]]] : memref<256xi64>
+// CHECK:   memref.store %[[ROLL_SHIFTED]], %{{.*}}[%[[ROLL_IV]]] : memref<256xi64>
+// CHECK: memref.store %[[ROLL_SAVED]], %{{.*}}[%[[ROLL_SP1]]] : memref<256xi64>
+
 module {
   func.func private @main() {
     %0 = forth.stack !forth.stack
@@ -44,6 +78,12 @@ module {
     %6 = forth.swap %5 : !forth.stack -> !forth.stack
     %7 = forth.over %6 : !forth.stack -> !forth.stack
     %8 = forth.rot %7 : !forth.stack -> !forth.stack
+    %9 = forth.nip %8 : !forth.stack -> !forth.stack
+    %10 = forth.tuck %9 : !forth.stack -> !forth.stack
+    %11 = forth.literal %10 2 : !forth.stack -> !forth.stack
+    %12 = forth.pick %11 : !forth.stack -> !forth.stack
+    %13 = forth.literal %12 2 : !forth.stack -> !forth.stack
+    %14 = forth.roll %13 : !forth.stack -> !forth.stack
     return
   }
 }

--- a/test/Translation/Forth/stack-ops.forth
+++ b/test/Translation/Forth/stack-ops.forth
@@ -6,4 +6,8 @@
 \ CHECK: forth.swap %{{.*}} : !forth.stack -> !forth.stack
 \ CHECK: forth.over %{{.*}} : !forth.stack -> !forth.stack
 \ CHECK: forth.rot %{{.*}} : !forth.stack -> !forth.stack
-1 DUP DROP SWAP OVER ROT
+\ CHECK: forth.nip %{{.*}} : !forth.stack -> !forth.stack
+\ CHECK: forth.tuck %{{.*}} : !forth.stack -> !forth.stack
+\ CHECK: forth.pick %{{.*}} : !forth.stack -> !forth.stack
+\ CHECK: forth.roll %{{.*}} : !forth.stack -> !forth.stack
+1 DUP DROP SWAP OVER ROT NIP TUCK PICK ROLL


### PR DESCRIPTION
## Summary

- Add NIP, TUCK, PICK, ROLL stack manipulation words to reduce stack gymnastics in complex GPU kernel index expressions
- PICK and ROLL use dynamic runtime indexing into the stack memref; ROLL lowers to an `scf.for` shift loop
- Includes translation tests, conversion tests, and all 35 tests pass

Closes #7

## Test plan

- [x] `check-warpforth` passes (35/35)
- [x] Translation test verifies Forth source parses to correct `forth.*` ops
- [x] Conversion test verifies MemRef lowering patterns for all 4 ops