### PR TITLE
feat: add comparison operators <> <= >= and BEGIN/WHILE/REPEAT loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ uv run ruff format gpu_test/
 
 - **Stack Type**: `!forth.stack` - untyped stack, programmer ensures type safety
 - **Operations**: All take stack as input and produce stack as output (except `forth.stack`)
-- **Supported Words**: literals, `DUP DROP SWAP OVER ROT NIP TUCK PICK ROLL`, `+ - * / MOD`, `AND OR XOR NOT LSHIFT RSHIFT`, `= < > 0=`, `@ !`, `CELLS`, `IF ELSE THEN`, `BEGIN UNTIL`, `DO LOOP I`, `TID-X/Y/Z BID-X/Y/Z BDIM-X/Y/Z GDIM-X/Y/Z GLOBAL-ID` (GPU indexing).
+- **Supported Words**: literals, `DUP DROP SWAP OVER ROT NIP TUCK PICK ROLL`, `+ - * / MOD`, `AND OR XOR NOT LSHIFT RSHIFT`, `= < > <> <= >= 0=`, `@ !`, `CELLS`, `IF ELSE THEN`, `BEGIN UNTIL`, `BEGIN WHILE REPEAT`, `DO LOOP I`, `TID-X/Y/Z BID-X/Y/Z BDIM-X/Y/Z GDIM-X/Y/Z GLOBAL-ID` (GPU indexing).
 - **Kernel Parameters**: Declared with `PARAM <name> <size>`, each becomes a `memref<Nxi64>` function argument with `forth.param_name` attribute. Using a param name in code pushes its byte address onto the stack via `forth.param_ref`
 - **Conversion**: `!forth.stack` → `memref<256xi64>` with explicit stack pointer
 - **GPU**: Functions wrapped in `gpu.module`, `main` gets `gpu.kernel` attribute, configured with bare pointers for NVVM conversion

--- a/include/warpforth/Dialect/Forth/ForthOps.td
+++ b/include/warpforth/Dialect/Forth/ForthOps.td
@@ -640,6 +640,51 @@ def Forth_GtOp : Forth_Op<"gt", [Pure]> {
   }];
 }
 
+def Forth_NeOp : Forth_Op<"ne", [Pure]> {
+  let summary = "Test inequality of top two stack elements";
+  let description = [{
+    Pops two values, pushes -1 (true) if not equal, 0 (false) otherwise.
+    Forth semantics: ( a b -- flag )
+  }];
+
+  let arguments = (ins Forth_StackType:$input_stack);
+  let results = (outs Forth_StackType:$output_stack);
+
+  let assemblyFormat = [{
+    $input_stack attr-dict `:` type($input_stack) `->` type($output_stack)
+  }];
+}
+
+def Forth_LeOp : Forth_Op<"le", [Pure]> {
+  let summary = "Test less-than-or-equal of top two stack elements";
+  let description = [{
+    Pops two values, pushes -1 (true) if a <= b, 0 (false) otherwise.
+    Forth semantics: ( a b -- flag )
+  }];
+
+  let arguments = (ins Forth_StackType:$input_stack);
+  let results = (outs Forth_StackType:$output_stack);
+
+  let assemblyFormat = [{
+    $input_stack attr-dict `:` type($input_stack) `->` type($output_stack)
+  }];
+}
+
+def Forth_GeOp : Forth_Op<"ge", [Pure]> {
+  let summary = "Test greater-than-or-equal of top two stack elements";
+  let description = [{
+    Pops two values, pushes -1 (true) if a >= b, 0 (false) otherwise.
+    Forth semantics: ( a b -- flag )
+  }];
+
+  let arguments = (ins Forth_StackType:$input_stack);
+  let results = (outs Forth_StackType:$output_stack);
+
+  let assemblyFormat = [{
+    $input_stack attr-dict `:` type($input_stack) `->` type($output_stack)
+  }];
+}
+
 def Forth_ZeroEqOp : Forth_Op<"zero_eq", [Pure]> {
   let summary = "Test if top of stack is zero";
   let description = [{
@@ -660,15 +705,18 @@ def Forth_ZeroEqOp : Forth_Op<"zero_eq", [Pure]> {
 //===----------------------------------------------------------------------===//
 
 def Forth_YieldOp : Forth_Op<"yield", [Pure, Terminator, ReturnLike,
-    ParentOneOf<["IfOp", "BeginUntilOp", "DoLoopOp"]>]> {
+    ParentOneOf<["IfOp", "BeginUntilOp", "BeginWhileRepeatOp", "DoLoopOp"]>]> {
   let summary = "Yield stack from control flow region";
   let description = [{
     Yields the current stack state from a control flow region back to
     the parent operation. Acts as a region terminator.
+    When the optional `while_cond` attribute is present, the yield acts as
+    a WHILE condition (continue when flag is non-zero) rather than
+    UNTIL (exit when flag is non-zero).
   }];
-  let arguments = (ins Forth_StackType:$result);
+  let arguments = (ins Forth_StackType:$result, OptionalAttr<UnitAttr>:$while_cond);
   let assemblyFormat = [{
-    $result attr-dict `:` type($result)
+    $result (`while_cond` $while_cond^)? attr-dict `:` type($result)
   }];
 }
 
@@ -715,6 +763,24 @@ def Forth_DoLoopOp : Forth_Op<"do_loop", [RecursiveMemoryEffects,
   let arguments = (ins Forth_StackType:$input_stack);
   let results = (outs Forth_StackType:$output_stack);
   let regions = (region SizedRegion<1>:$body_region);
+  let hasCustomAssemblyFormat = 1;
+}
+
+def Forth_BeginWhileRepeatOp : Forth_Op<"begin_while_repeat",
+    [RecursiveMemoryEffects,
+    DeclareOpInterfaceMethods<RegionBranchOpInterface,
+        ["getEntrySuccessorOperands"]>]> {
+  let summary = "Pre-test loop (BEGIN/WHILE/REPEAT)";
+  let description = [{
+    BEGIN/WHILE/REPEAT loop. The condition region runs first, WHILE pops flag.
+    If flag is non-zero, the body region executes and loops back to condition.
+    If flag is zero, the loop exits.
+    Stack effect: ( -- ) with flag consumed each iteration.
+  }];
+  let arguments = (ins Forth_StackType:$input_stack);
+  let results = (outs Forth_StackType:$output_stack);
+  let regions = (region SizedRegion<1>:$condition_region,
+                        SizedRegion<1>:$body_region);
   let hasCustomAssemblyFormat = 1;
 }
 

--- a/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
+++ b/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
@@ -783,8 +783,9 @@ struct GlobalIdOpConversion : public OpConversionPattern<forth::GlobalIdOp> {
 };
 
 /// Conversion pattern for forth.yield operation.
-/// Context-aware: inside scf.while's `before` region (from BeginUntilOp),
-/// emits flag-pop + scf.condition; otherwise emits scf.yield with SP.
+/// Context-aware: inside scf.while's `before` region (from BeginUntilOp or
+/// BeginWhileRepeatOp), emits flag-pop + scf.condition; otherwise emits
+/// scf.yield with SP.
 struct YieldOpConversion : public OpConversionPattern<forth::YieldOp> {
   YieldOpConversion(const TypeConverter &typeConverter, MLIRContext *context)
       : OpConversionPattern<forth::YieldOp>(typeConverter, context) {}

--- a/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
+++ b/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
@@ -488,7 +488,7 @@ struct BinaryCmpOpConversion : public OpConversionPattern<ForthOp> {
     // Compare
     Value cmp = rewriter.create<arith::CmpIOp>(loc, predicate, a, b);
 
-    // Extend i1 to i64: true → -1 (all bits set), false → 0
+    // Extend i1 to i64: true = -1 (all bits set), false = 0
     Value result =
         rewriter.create<arith::ExtSIOp>(loc, rewriter.getI64Type(), cmp);
 
@@ -570,7 +570,7 @@ struct ZeroEqOpConversion : public OpConversionPattern<forth::ZeroEqOp> {
     Value cmp =
         rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, a, zero);
 
-    // Extend i1 to i64: true → -1, false → 0
+    // Extend i1 to i64: true = -1, false = 0
     Value result =
         rewriter.create<arith::ExtSIOp>(loc, rewriter.getI64Type(), cmp);
 
@@ -862,7 +862,7 @@ struct IfOpConversion : public OpConversionPattern<forth::IfOp> {
                                             /*addElseBlock=*/true);
 
     // Convert block signatures and inline regions into scf.if.
-    // convertRegionTypes converts !forth.stack block arg → {memref, index}
+    // convertRegionTypes converts !forth.stack block arg to {memref, index}
     // and inserts tracked materializations (unrealized_conversion_cast).
     // We inline into scf.if and mergeBlocks to substitute the converted
     // block args with parent-scope values. The original materialization
@@ -918,7 +918,7 @@ struct BeginUntilOpConversion
     auto whileOp = rewriter.create<scf::WhileOp>(loc, TypeRange{indexType},
                                                  ValueRange{stackPtr});
 
-    // --- Before region (body): convert + inline ---
+    // Before region (body): convert + inline.
     Region &bodyRegion = op.getBodyRegion();
     if (failed(rewriter.convertRegionTypes(&bodyRegion, *getTypeConverter())))
       return failure();
@@ -936,7 +936,7 @@ struct BeginUntilOpConversion
     Value beforeSP = newBeforeBlock->getArgument(0);
     rewriter.mergeBlocks(&beforeBlock, newBeforeBlock, {memref, beforeSP});
 
-    // --- After region (identity): just yield the SP ---
+    // After region (identity): just yield the SP.
     Block *afterBlock = rewriter.createBlock(&whileOp.getAfter());
     afterBlock->addArgument(indexType, loc);
     Value afterSP = afterBlock->getArgument(0);
@@ -974,7 +974,7 @@ struct BeginWhileRepeatOpConversion
     auto whileOp = rewriter.create<scf::WhileOp>(loc, TypeRange{indexType},
                                                  ValueRange{stackPtr});
 
-    // --- Before region (condition): convert + inline ---
+    // Before region (condition): convert + inline.
     Region &condRegion = op.getConditionRegion();
     if (failed(rewriter.convertRegionTypes(&condRegion, *getTypeConverter())))
       return failure();
@@ -988,7 +988,7 @@ struct BeginWhileRepeatOpConversion
     Value beforeSP = newBeforeBlock->getArgument(0);
     rewriter.mergeBlocks(&beforeBlock, newBeforeBlock, {memref, beforeSP});
 
-    // --- After region (body): convert + inline ---
+    // After region (body): convert + inline.
     Region &bodyRegion = op.getBodyRegion();
     if (failed(rewriter.convertRegionTypes(&bodyRegion, *getTypeConverter())))
       return failure();
@@ -1034,7 +1034,7 @@ struct DoLoopOpConversion : public OpConversionPattern<forth::DoLoopOp> {
     Value limitI64 = rewriter.create<memref::LoadOp>(loc, memref, spAfterStart);
     Value spAfterPops = rewriter.create<arith::SubIOp>(loc, spAfterStart, one);
 
-    // Cast i64 → index for scf.for bounds
+    // Cast i64 to index for scf.for bounds
     Value startIdx =
         rewriter.create<arith::IndexCastOp>(loc, indexType, startI64);
     Value limitIdx =
@@ -1095,7 +1095,7 @@ struct LoopIndexOpConversion : public OpConversionPattern<forth::LoopIndexOp> {
     if (!forOp)
       return rewriter.notifyMatchFailure(op, "not inside an scf.for");
 
-    // Get induction variable and cast index → i64
+    // Get induction variable and cast index to i64
     Value iv = forOp.getInductionVar();
     Value ivI64 =
         rewriter.create<arith::IndexCastOp>(loc, rewriter.getI64Type(), iv);

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.h
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.h
@@ -47,6 +47,10 @@ public:
   /// Reset lexer to beginning of buffer.
   void reset();
 
+  /// Save/restore lexer position for lookahead.
+  const char *getPosition() const { return curPtr; }
+  void setPosition(const char *pos) { curPtr = pos; }
+
 private:
   llvm::SourceMgr &sourceMgr;
   unsigned bufferID;
@@ -111,6 +115,13 @@ private:
 
   /// Parse a BEGIN/UNTIL loop, creating a forth.begin_until op.
   Value parseBeginUntil(Value inputStack, Location loc);
+
+  /// Parse a BEGIN/WHILE/REPEAT loop, creating a forth.begin_while_repeat op.
+  Value parseBeginWhileRepeat(Value inputStack, Location loc);
+
+  /// Lookahead: is the current BEGIN a WHILE loop (vs UNTIL)?
+  /// Saves and restores lexer position.
+  bool isWhileLoop();
 
   /// Parse a DO/LOOP counted loop, creating a forth.do_loop op.
   Value parseDoLoop(Value inputStack, Location loc);

--- a/test/Conversion/ForthToMemRef/begin-while-repeat.mlir
+++ b/test/Conversion/ForthToMemRef/begin-while-repeat.mlir
@@ -1,0 +1,44 @@
+// RUN: %warpforth-opt --convert-forth-to-memref %s | %FileCheck %s
+
+// CHECK-LABEL: func.func private @main
+
+// Verify scf.while with index iter arg:
+// CHECK: scf.while (%{{.*}} = %{{.*}}) : (index) -> index {
+
+// Condition region: operations + flag pop + condition (ne for WHILE)
+// CHECK:   memref.load
+// CHECK:   arith.cmpi sgt
+// CHECK:   arith.extsi
+// CHECK:   memref.load
+// CHECK:   arith.subi
+// CHECK:   arith.cmpi ne
+// CHECK:   scf.condition(%{{.*}}) %{{.*}} : index
+
+// Body region: operations + yield
+// CHECK: } do {
+// CHECK:   arith.addi
+// CHECK:   memref.store
+// CHECK:   memref.load
+// CHECK:   arith.subi
+// CHECK:   scf.yield %{{.*}} : index
+// CHECK: }
+
+module {
+  func.func private @main() {
+    %0 = forth.stack !forth.stack
+    %1 = forth.literal %0 10 : !forth.stack -> !forth.stack
+    %2 = forth.begin_while_repeat %1 : !forth.stack -> !forth.stack {
+    ^bb0(%arg0: !forth.stack):
+      %3 = forth.dup %arg0 : !forth.stack -> !forth.stack
+      %4 = forth.literal %3 0 : !forth.stack -> !forth.stack
+      %5 = forth.gt %4 : !forth.stack -> !forth.stack
+      forth.yield %5 while_cond : !forth.stack
+    } do {
+    ^bb0(%arg1: !forth.stack):
+      %6 = forth.literal %arg1 1 : !forth.stack -> !forth.stack
+      %7 = forth.sub %6 : !forth.stack -> !forth.stack
+      forth.yield %7 : !forth.stack
+    }
+    return
+  }
+}

--- a/test/Conversion/ForthToMemRef/comparison.mlir
+++ b/test/Conversion/ForthToMemRef/comparison.mlir
@@ -31,6 +31,27 @@
 // CHECK: arith.extsi %{{.*}} : i1 to i64
 // CHECK: memref.store
 
+// ne: load two values, arith.cmpi ne, extsi to i64, store
+// CHECK: memref.load
+// CHECK: memref.load
+// CHECK: arith.cmpi ne, %{{.*}}, %{{.*}} : i64
+// CHECK: arith.extsi %{{.*}} : i1 to i64
+// CHECK: memref.store
+
+// le: load two values, arith.cmpi sle, extsi to i64, store
+// CHECK: memref.load
+// CHECK: memref.load
+// CHECK: arith.cmpi sle, %{{.*}}, %{{.*}} : i64
+// CHECK: arith.extsi %{{.*}} : i1 to i64
+// CHECK: memref.store
+
+// ge: load two values, arith.cmpi sge, extsi to i64, store
+// CHECK: memref.load
+// CHECK: memref.load
+// CHECK: arith.cmpi sge, %{{.*}}, %{{.*}} : i64
+// CHECK: arith.extsi %{{.*}} : i1 to i64
+// CHECK: memref.store
+
 module {
   func.func private @main() {
     %0 = forth.stack !forth.stack
@@ -45,6 +66,15 @@ module {
     %9 = forth.gt %8 : !forth.stack -> !forth.stack
     %10 = forth.literal %9 0 : !forth.stack -> !forth.stack
     %11 = forth.zero_eq %10 : !forth.stack -> !forth.stack
+    %12 = forth.literal %11 7 : !forth.stack -> !forth.stack
+    %13 = forth.literal %12 8 : !forth.stack -> !forth.stack
+    %14 = forth.ne %13 : !forth.stack -> !forth.stack
+    %15 = forth.literal %14 9 : !forth.stack -> !forth.stack
+    %16 = forth.literal %15 10 : !forth.stack -> !forth.stack
+    %17 = forth.le %16 : !forth.stack -> !forth.stack
+    %18 = forth.literal %17 11 : !forth.stack -> !forth.stack
+    %19 = forth.literal %18 12 : !forth.stack -> !forth.stack
+    %20 = forth.ge %19 : !forth.stack -> !forth.stack
     return
   }
 }

--- a/test/Pipeline/begin-while-repeat.forth
+++ b/test/Pipeline/begin-while-repeat.forth
@@ -1,0 +1,15 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --warpforth-pipeline | %FileCheck %s
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --convert-forth-to-memref --convert-scf-to-cf --convert-forth-to-gpu | %FileCheck %s --check-prefix=MID
+
+\ Verify that BEGIN/WHILE/REPEAT through the full pipeline produces a gpu.binary
+\ CHECK: gpu.binary @warpforth_module
+
+\ Verify intermediate MLIR: gpu.func with conditional branch
+\ MID: gpu.module @warpforth_module
+\ MID: gpu.func @main(%arg0: memref<4xi64> {forth.param_name = "DATA"}) kernel
+\ MID: cf.br
+\ MID: cf.cond_br
+\ MID: gpu.return
+
+PARAM DATA 4
+10 BEGIN DUP 0 > WHILE 1 - REPEAT DATA 0 CELLS + !

--- a/test/Translation/Forth/begin-while-repeat.forth
+++ b/test/Translation/Forth/begin-while-repeat.forth
@@ -1,0 +1,20 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %FileCheck %s
+
+\ Verify BEGIN/WHILE/REPEAT parsing produces forth.begin_while_repeat
+\ with condition and body regions
+
+\ CHECK: %[[S0:.*]] = forth.stack
+\ CHECK: %[[S1:.*]] = forth.literal %[[S0]] 10
+\ CHECK: %[[LOOP:.*]] = forth.begin_while_repeat %[[S1]]
+\ CHECK:   ^bb0(%[[CARG:.*]]: !forth.stack):
+\ CHECK:   forth.dup
+\ CHECK:   forth.literal
+\ CHECK:   forth.gt
+\ CHECK:   forth.yield %{{.*}} while_cond
+\ CHECK: } do {
+\ CHECK:   ^bb0(%[[BARG:.*]]: !forth.stack):
+\ CHECK:   forth.literal
+\ CHECK:   forth.sub
+\ CHECK:   forth.yield
+\ CHECK: }
+10 BEGIN DUP 0 > WHILE 1 - REPEAT

--- a/test/Translation/Forth/comparison-ops.forth
+++ b/test/Translation/Forth/comparison-ops.forth
@@ -12,5 +12,14 @@
 \ CHECK: %[[S8:.*]] = forth.literal %[[S7]]
 \ CHECK: %[[S9:.*]] = forth.gt %[[S8]]
 \ CHECK: %[[S10:.*]] = forth.literal %[[S9]]
-\ CHECK: %{{.*}} = forth.zero_eq %[[S10]]
-1 2 = 3 4 < 5 6 > 0 0=
+\ CHECK: %[[S11:.*]] = forth.zero_eq %[[S10]]
+\ CHECK: %[[S12:.*]] = forth.literal %[[S11]]
+\ CHECK: %[[S13:.*]] = forth.literal %[[S12]]
+\ CHECK: %[[S14:.*]] = forth.ne %[[S13]]
+\ CHECK: %[[S15:.*]] = forth.literal %[[S14]]
+\ CHECK: %[[S16:.*]] = forth.literal %[[S15]]
+\ CHECK: %[[S17:.*]] = forth.le %[[S16]]
+\ CHECK: %[[S18:.*]] = forth.literal %[[S17]]
+\ CHECK: %[[S19:.*]] = forth.literal %[[S18]]
+\ CHECK: %{{.*}} = forth.ge %[[S19]]
+1 2 = 3 4 < 5 6 > 0 0= 7 8 <> 9 10 <= 11 12 >=


### PR DESCRIPTION
## Summary
- Add missing comparison operators `<>` (not-equal), `<=` (less-or-equal), `>=` (greater-or-equal)
- Implement `BEGIN/WHILE/REPEAT` pre-test loop as a two-region op that lowers to `scf.while`
- Update `CLAUDE.md` supported words list

## Test plan
- [x] Extended `comparison-ops.forth` translation test with `<>`, `<=`, `>=`
- [x] Extended `comparison.mlir` conversion test with `ne`, `le`, `ge` predicates
- [x] New `begin-while-repeat.forth` translation test
- [x] New `begin-while-repeat.mlir` conversion test
- [x] New `begin-while-repeat.forth` full pipeline test
- [x] All 38 tests pass

Closes #9