### PR TITLE
feat(translate): implement EXIT word and fix UNLOOP for early loop exit

### DIFF
--- a/test/Pipeline/exit.forth
+++ b/test/Pipeline/exit.forth
@@ -1,0 +1,6 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --warpforth-pipeline | %FileCheck %s
+\ CHECK: gpu.binary @warpforth_module
+
+PARAM DATA 4
+: DO-EXIT 1 IF EXIT THEN 42 ;
+DO-EXIT DATA 0 CELLS + !

--- a/test/Pipeline/unloop-exit.forth
+++ b/test/Pipeline/unloop-exit.forth
@@ -1,0 +1,6 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --warpforth-pipeline | %FileCheck %s
+\ CHECK: gpu.binary @warpforth_module
+
+PARAM DATA 4
+: FIND-FIVE  10 0 DO I 5 = IF UNLOOP EXIT THEN LOOP 0 ;
+FIND-FIVE DATA 0 CELLS + !

--- a/test/Translation/Forth/exit-outside-word-error.forth
+++ b/test/Translation/Forth/exit-outside-word-error.forth
@@ -1,0 +1,3 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: EXIT outside word definition
+EXIT

--- a/test/Translation/Forth/exit.forth
+++ b/test/Translation/Forth/exit.forth
@@ -1,0 +1,13 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %FileCheck %s
+
+\ CHECK: func.func private @EARLY_EXIT(%[[A:.*]]: !forth.stack) -> !forth.stack
+\ CHECK:   cf.cond_br %{{.*}}, ^[[THEN:bb.*]](%{{.*}}), ^[[JOIN:bb.*]](%{{.*}})
+\ CHECK: ^[[THEN]](%[[T:.*]]: !forth.stack):
+\ CHECK:   cf.cond_br %true, ^[[RET:bb.*]](%[[T]]{{.*}}), ^[[DEAD:bb.*]](%[[T]]
+\ CHECK: ^[[JOIN]](%{{.*}}: !forth.stack):
+\ CHECK:   return %{{.*}} : !forth.stack
+\ CHECK: ^[[RET]](%[[R:.*]]: !forth.stack):
+\ CHECK:   return %[[R]] : !forth.stack
+
+: EARLY-EXIT 1 IF EXIT THEN 42 ;
+EARLY-EXIT

--- a/test/Translation/Forth/unloop-exit.forth
+++ b/test/Translation/Forth/unloop-exit.forth
@@ -1,0 +1,21 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %FileCheck %s
+
+\ Verify the UNLOOP EXIT idiom: early return from a DO LOOP inside a word.
+
+\ CHECK: func.func private @FIND_FIVE(%{{.*}}: !forth.stack) -> !forth.stack
+\ CHECK: memref.alloca
+\ CHECK: cf.br ^bb[[#CHECK:]]
+\ CHECK: ^bb[[#CHECK]](%{{.*}}: !forth.stack):
+\ CHECK: cf.cond_br %{{.*}}, ^bb[[#BODY:]](%{{.*}}), ^bb[[#EXIT:]](%{{.*}})
+\ CHECK: ^bb[[#BODY]](%{{.*}}: !forth.stack):
+\ CHECK: forth.eq
+\ CHECK: cf.cond_br %{{.*}}, ^bb[[#THEN:]](%{{.*}}), ^bb[[#ENDIF:]](%{{.*}})
+\ CHECK: ^bb[[#EXIT]](%{{.*}}: !forth.stack):
+\ CHECK: return
+\ CHECK: ^bb[[#THEN]](%[[T:.*]]: !forth.stack):
+\ CHECK: cf.cond_br %true, ^bb[[#RET:]](%[[T]]{{.*}})
+\ CHECK: ^bb[[#RET]](%[[R:.*]]: !forth.stack):
+\ CHECK: return %[[R]] : !forth.stack
+
+: FIND-FIVE  10 0 DO I 5 = IF UNLOOP EXIT THEN LOOP 0 ;
+FIND-FIVE


### PR DESCRIPTION
## Summary
- Implement EXIT word for early return from user-defined words (colon definitions), emitting `func.return` via a dummy `cond_br` pattern to keep dead blocks structurally reachable for dialect conversion
- Fix UNLOOP to not pop the loop stack at parse time, enabling the idiomatic `UNLOOP EXIT` pattern for early loop exit
- Error on EXIT outside a word definition

## Test plan
- [x] Translation test: EXIT inside IF/THEN emits return (`test/Translation/Forth/exit.forth`)
- [x] Negative test: EXIT outside word definition (`test/Translation/Forth/exit-outside-word-error.forth`)
- [x] Translation test: UNLOOP EXIT inside DO LOOP (`test/Translation/Forth/unloop-exit.forth`)
- [x] Pipeline test: EXIT compiles to gpu.binary (`test/Pipeline/exit.forth`)
- [x] Pipeline test: UNLOOP EXIT compiles to gpu.binary (`test/Pipeline/unloop-exit.forth`)
- [x] All 54 tests pass

Closes #24