### PR TITLE
feat: replace PARAM with \! kernel header syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ uv run ruff format gpu_test/
 - **Stack Type**: `!forth.stack` - untyped stack, programmer ensures type safety
 - **Operations**: All take stack as input and produce stack as output (except `forth.stack`)
 - **Supported Words**: literals, `DUP DROP SWAP OVER ROT NIP TUCK PICK ROLL`, `+ - * / MOD`, `AND OR XOR NOT LSHIFT RSHIFT`, `= < > <> <= >= 0=`, `@ !`, `CELLS`, `IF ELSE THEN`, `BEGIN UNTIL`, `BEGIN WHILE REPEAT`, `DO LOOP +LOOP I J K`, `LEAVE UNLOOP EXIT`, `TID-X/Y/Z BID-X/Y/Z BDIM-X/Y/Z GDIM-X/Y/Z GLOBAL-ID` (GPU indexing).
-- **Kernel Parameters**: Declared with `PARAM <name> <size>`, each becomes a `memref<Nxi64>` function argument with `forth.param_name` attribute. Using a param name in code pushes its byte address onto the stack via `forth.param_ref`
+- **Kernel Parameters**: Declared in the `\!` header. `\! kernel <name>` is required and must appear first. `\! param <name> i64[<N>]` becomes a `memref<Nxi64>` argument; `\! param <name> i64` becomes an `i64` argument. Using a param name in code emits `forth.param_ref` (arrays push address; scalars push value).
 - **Conversion**: `!forth.stack` → `memref<256xi64>` with explicit stack pointer
 - **GPU**: Functions wrapped in `gpu.module`, `main` gets `gpu.kernel` attribute, configured with bare pointers for NVVM conversion
 - **User-defined Words**: Modeled as `func.func` with signature `(!forth.stack) -> !forth.stack`, called via `func.call`

--- a/gpu_test/test_kernels.py
+++ b/gpu_test/test_kernels.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.gpu
 def test_addition(kernel_runner: KernelRunner) -> None:
     """3 + 4 = 7."""
     result = kernel_runner.run(
-        forth_source="PARAM DATA 256\n3 4 +\n0 CELLS DATA + !",
+        forth_source="\\! kernel main\n\\! param DATA i64[256]\n3 4 +\n0 CELLS DATA + !",
     )
     assert result[0] == 7
 
@@ -26,7 +26,7 @@ def test_addition(kernel_runner: KernelRunner) -> None:
 def test_subtraction(kernel_runner: KernelRunner) -> None:
     """10 - 3 = 7."""
     result = kernel_runner.run(
-        forth_source="PARAM DATA 256\n10 3 -\n0 CELLS DATA + !",
+        forth_source="\\! kernel main\n\\! param DATA i64[256]\n10 3 -\n0 CELLS DATA + !",
     )
     assert result[0] == 7
 
@@ -34,7 +34,7 @@ def test_subtraction(kernel_runner: KernelRunner) -> None:
 def test_multiplication(kernel_runner: KernelRunner) -> None:
     """6 * 7 = 42."""
     result = kernel_runner.run(
-        forth_source="PARAM DATA 256\n6 7 *\n0 CELLS DATA + !",
+        forth_source="\\! kernel main\n\\! param DATA i64[256]\n6 7 *\n0 CELLS DATA + !",
     )
     assert result[0] == 42
 
@@ -42,7 +42,7 @@ def test_multiplication(kernel_runner: KernelRunner) -> None:
 def test_division(kernel_runner: KernelRunner) -> None:
     """42 / 6 = 7."""
     result = kernel_runner.run(
-        forth_source="PARAM DATA 256\n42 6 /\n0 CELLS DATA + !",
+        forth_source="\\! kernel main\n\\! param DATA i64[256]\n42 6 /\n0 CELLS DATA + !",
     )
     assert result[0] == 7
 
@@ -50,7 +50,7 @@ def test_division(kernel_runner: KernelRunner) -> None:
 def test_modulo(kernel_runner: KernelRunner) -> None:
     """17 MOD 5 = 2."""
     result = kernel_runner.run(
-        forth_source="PARAM DATA 256\n17 5 MOD\n0 CELLS DATA + !",
+        forth_source="\\! kernel main\n\\! param DATA i64[256]\n17 5 MOD\n0 CELLS DATA + !",
     )
     assert result[0] == 2
 
@@ -61,7 +61,9 @@ def test_modulo(kernel_runner: KernelRunner) -> None:
 def test_dup(kernel_runner: KernelRunner) -> None:
     """DUP duplicates top of stack: 5 DUP → [5, 5]."""
     result = kernel_runner.run(
-        forth_source=("PARAM DATA 256\n5 DUP\n1 CELLS DATA + !\n0 CELLS DATA + !"),
+        forth_source=(
+            "\\! kernel main\n\\! param DATA i64[256]\n5 DUP\n1 CELLS DATA + !\n0 CELLS DATA + !"
+        ),
         output_count=2,
     )
     assert result == [5, 5]
@@ -70,7 +72,9 @@ def test_dup(kernel_runner: KernelRunner) -> None:
 def test_swap(kernel_runner: KernelRunner) -> None:
     """SWAP exchanges top two: 1 2 SWAP → [2, 1]."""
     result = kernel_runner.run(
-        forth_source=("PARAM DATA 256\n1 2 SWAP\n1 CELLS DATA + !\n0 CELLS DATA + !"),
+        forth_source=(
+            "\\! kernel main\n\\! param DATA i64[256]\n1 2 SWAP\n1 CELLS DATA + !\n0 CELLS DATA + !"
+        ),
         output_count=2,
     )
     assert result == [2, 1]
@@ -80,7 +84,12 @@ def test_over(kernel_runner: KernelRunner) -> None:
     """OVER copies second element: 1 2 OVER → [1, 2, 1]."""
     result = kernel_runner.run(
         forth_source=(
-            "PARAM DATA 256\n1 2 OVER\n2 CELLS DATA + !\n1 CELLS DATA + !\n0 CELLS DATA + !"
+            "\\! kernel main\n"
+            "\\! param DATA i64[256]\n"
+            "1 2 OVER\n"
+            "2 CELLS DATA + !\n"
+            "1 CELLS DATA + !\n"
+            "0 CELLS DATA + !"
         ),
         output_count=3,
     )
@@ -91,7 +100,12 @@ def test_rot(kernel_runner: KernelRunner) -> None:
     """ROT rotates top three: 1 2 3 ROT → [2, 3, 1]."""
     result = kernel_runner.run(
         forth_source=(
-            "PARAM DATA 256\n1 2 3 ROT\n2 CELLS DATA + !\n1 CELLS DATA + !\n0 CELLS DATA + !"
+            "\\! kernel main\n"
+            "\\! param DATA i64[256]\n"
+            "1 2 3 ROT\n"
+            "2 CELLS DATA + !\n"
+            "1 CELLS DATA + !\n"
+            "0 CELLS DATA + !"
         ),
         output_count=3,
     )
@@ -101,7 +115,7 @@ def test_rot(kernel_runner: KernelRunner) -> None:
 def test_drop(kernel_runner: KernelRunner) -> None:
     """DROP removes top: 1 2 DROP → [1]."""
     result = kernel_runner.run(
-        forth_source=("PARAM DATA 256\n1 2 DROP\n0 CELLS DATA + !"),
+        forth_source=("\\! kernel main\n\\! param DATA i64[256]\n1 2 DROP\n0 CELLS DATA + !"),
     )
     assert result[0] == 1
 
@@ -113,7 +127,7 @@ def test_comparisons(kernel_runner: KernelRunner) -> None:
     """Test =, <, >, 0= in a single kernel. True = -1, False = 0."""
     result = kernel_runner.run(
         forth_source=(
-            "PARAM DATA 256\n"
+            "\\! kernel main\n\\! param DATA i64[256]\n"
             "5 5 =  0 CELLS DATA + !\n"
             "3 5 <  1 CELLS DATA + !\n"
             "5 3 >  2 CELLS DATA + !\n"
@@ -130,7 +144,14 @@ def test_comparisons(kernel_runner: KernelRunner) -> None:
 def test_if_else_then(kernel_runner: KernelRunner) -> None:
     """IF/ELSE/THEN: if DATA[0] > 0, write 1 to DATA[1], else write 2."""
     result = kernel_runner.run(
-        forth_source=("PARAM DATA 256\n0 CELLS DATA + @\n0 >\nIF 1 ELSE 2 THEN\n1 CELLS DATA + !"),
+        forth_source=(
+            "\\! kernel main\n"
+            "\\! param DATA i64[256]\n"
+            "0 CELLS DATA + @\n"
+            "0 >\n"
+            "IF 1 ELSE 2 THEN\n"
+            "1 CELLS DATA + !"
+        ),
         params={"DATA": [5]},
         output_count=2,
     )
@@ -140,7 +161,9 @@ def test_if_else_then(kernel_runner: KernelRunner) -> None:
 def test_begin_until(kernel_runner: KernelRunner) -> None:
     """BEGIN/UNTIL countdown: 10 BEGIN 1- DUP 0= UNTIL → final value is 0."""
     result = kernel_runner.run(
-        forth_source=("PARAM DATA 256\n10 BEGIN 1 - DUP 0= UNTIL\n0 CELLS DATA + !"),
+        forth_source=(
+            "\\! kernel main\n\\! param DATA i64[256]\n10 BEGIN 1 - DUP 0= UNTIL\n0 CELLS DATA + !"
+        ),
     )
     assert result[0] == 0
 
@@ -148,7 +171,9 @@ def test_begin_until(kernel_runner: KernelRunner) -> None:
 def test_do_loop(kernel_runner: KernelRunner) -> None:
     """DO/LOOP: write I values 0..4 to DATA[0..4]."""
     result = kernel_runner.run(
-        forth_source=("PARAM DATA 256\n5 0 DO\n  I I CELLS DATA + !\nLOOP"),
+        forth_source=(
+            "\\! kernel main\n\\! param DATA i64[256]\n5 0 DO\n  I I CELLS DATA + !\nLOOP"
+        ),
         output_count=5,
     )
     assert result == [0, 1, 2, 3, 4]
@@ -157,7 +182,16 @@ def test_do_loop(kernel_runner: KernelRunner) -> None:
 def test_do_plus_loop(kernel_runner: KernelRunner) -> None:
     """DO/+LOOP: write I values 0, 2, 4, 6, 8 to DATA[0..4]."""
     result = kernel_runner.run(
-        forth_source=("PARAM DATA 256\n0\n10 0 DO\n  I OVER CELLS DATA + !\n  1 +\n2 +LOOP\nDROP"),
+        forth_source=(
+            "\\! kernel main\n"
+            "\\! param DATA i64[256]\n"
+            "0\n"
+            "10 0 DO\n"
+            "  I OVER CELLS DATA + !\n"
+            "  1 +\n"
+            "2 +LOOP\n"
+            "DROP"
+        ),
         output_count=5,
     )
     assert result == [0, 2, 4, 6, 8]
@@ -166,7 +200,16 @@ def test_do_plus_loop(kernel_runner: KernelRunner) -> None:
 def test_do_plus_loop_negative(kernel_runner: KernelRunner) -> None:
     """DO/+LOOP with negative step: count down from 10 to 1."""
     result = kernel_runner.run(
-        forth_source=("PARAM DATA 256\n0\n0 10 DO\n  I OVER CELLS DATA + !\n  1 +\n-1 +LOOP\nDROP"),
+        forth_source=(
+            "\\! kernel main\n"
+            "\\! param DATA i64[256]\n"
+            "0\n"
+            "0 10 DO\n"
+            "  I OVER CELLS DATA + !\n"
+            "  1 +\n"
+            "-1 +LOOP\n"
+            "DROP"
+        ),
         output_count=10,
     )
     assert result == [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
@@ -180,7 +223,7 @@ def test_multi_while(kernel_runner: KernelRunner) -> None:
     """
     result = kernel_runner.run(
         forth_source=(
-            "PARAM DATA 256\n"
+            "\\! kernel main\n\\! param DATA i64[256]\n"
             "20 BEGIN DUP 10 > WHILE DUP 2 MOD 0= WHILE 1 - REPEAT THEN\n"
             "0 CELLS DATA + !"
         ),
@@ -196,7 +239,10 @@ def test_while_until(kernel_runner: KernelRunner) -> None:
     """
     result = kernel_runner.run(
         forth_source=(
-            "PARAM DATA 256\n10 BEGIN DUP 0 > WHILE 1 - DUP 5 = UNTIL THEN\n0 CELLS DATA + !"
+            "\\! kernel main\n"
+            "\\! param DATA i64[256]\n"
+            "10 BEGIN DUP 0 > WHILE 1 - DUP 5 = UNTIL THEN\n"
+            "0 CELLS DATA + !"
         ),
     )
     assert result[0] == 5
@@ -208,7 +254,7 @@ def test_while_until(kernel_runner: KernelRunner) -> None:
 def test_global_id(kernel_runner: KernelRunner) -> None:
     """4 threads each write GLOBAL-ID to DATA[GLOBAL-ID]."""
     result = kernel_runner.run(
-        forth_source=("PARAM DATA 256\nGLOBAL-ID\nDUP CELLS DATA + !"),
+        forth_source=("\\! kernel main\n\\! param DATA i64[256]\nGLOBAL-ID\nDUP CELLS DATA + !"),
         block=(4, 1, 1),
         output_count=4,
     )
@@ -219,8 +265,8 @@ def test_multi_param(kernel_runner: KernelRunner) -> None:
     """Two params: each thread reads INPUT[i], doubles it, writes OUTPUT[i]."""
     result = kernel_runner.run(
         forth_source=(
-            "PARAM INPUT 4\n"
-            "PARAM OUTPUT 4\n"
+            "\\! kernel main\n\\! param INPUT i64[4]\n"
+            "\\! param OUTPUT i64[4]\n"
             "GLOBAL-ID\n"
             "DUP CELLS INPUT + @\n"
             "DUP +\n"
@@ -243,9 +289,9 @@ def test_naive_matmul_i64(kernel_runner: KernelRunner) -> None:
     # GLOBAL-ID maps to (row, col) with row = gid / N, col = gid MOD N.
     result = kernel_runner.run(
         forth_source=(
-            "PARAM A 8\n"
-            "PARAM B 12\n"
-            "PARAM C 6\n"
+            "\\! kernel main\n\\! param A i64[8]\n"
+            "\\! param B i64[12]\n"
+            "\\! param C i64[6]\n"
             "GLOBAL-ID\n"
             "DUP 3 /\n"
             "SWAP 3 MOD\n"
@@ -277,6 +323,8 @@ def test_naive_matmul_i64(kernel_runner: KernelRunner) -> None:
 def test_user_defined_word(kernel_runner: KernelRunner) -> None:
     """: DOUBLE DUP + ; then 5 DOUBLE → 10."""
     result = kernel_runner.run(
-        forth_source=("PARAM DATA 256\n: DOUBLE DUP + ;\n5 DOUBLE\n0 CELLS DATA + !"),
+        forth_source=(
+            "\\! kernel main\n\\! param DATA i64[256]\n: DOUBLE DUP + ;\n5 DOUBLE\n0 CELLS DATA + !"
+        ),
     )
     assert result[0] == 10

--- a/lib/Conversion/ForthToGPU/ForthToGPU.cpp
+++ b/lib/Conversion/ForthToGPU/ForthToGPU.cpp
@@ -182,7 +182,7 @@ private:
 
   void convertFuncToGPU(func::FuncOp funcOp, gpu::GPUModuleOp gpuModule,
                         IRRewriter &rewriter) {
-    bool isKernel = funcOp.getName() == "main";
+    bool isKernel = funcOp->hasAttr("forth.kernel");
 
     if (isKernel) {
       auto gpuFunc = createGPUFunc(funcOp, gpuModule, rewriter);

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.h
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.h
@@ -25,6 +25,7 @@ struct ParamDecl {
 };
 
 /// A declared shared memory region: `shared <name> <type>`.
+/// TODO: Not yet consumed — scaffolding for shared memory support.
 struct SharedDecl {
   std::string name;
   bool isArray = false;

--- a/test/Conversion/ForthToGPU/basic-gpu-wrap.mlir
+++ b/test/Conversion/ForthToGPU/basic-gpu-wrap.mlir
@@ -6,7 +6,7 @@
 // CHECK: gpu.return
 
 module {
-  func.func private @main() {
+  func.func private @main() attributes {forth.kernel} {
     %alloca = memref.alloca() : memref<256xi64>
     %c0 = arith.constant 0 : index
     return

--- a/test/Conversion/ForthToGPU/intrinsic-conversion.mlir
+++ b/test/Conversion/ForthToGPU/intrinsic-conversion.mlir
@@ -10,7 +10,7 @@
 // CHECK: gpu.grid_dim y
 
 module {
-  func.func private @main() {
+  func.func private @main() attributes {forth.kernel} {
     %alloca = memref.alloca() : memref<256xi64>
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index

--- a/test/Conversion/ForthToGPU/private-functions.mlir
+++ b/test/Conversion/ForthToGPU/private-functions.mlir
@@ -14,7 +14,7 @@ module {
   func.func private @helper(%arg0: memref<256xi64>, %arg1: index) -> (memref<256xi64>, index) {
     return %arg0, %arg1 : memref<256xi64>, index
   }
-  func.func private @main() {
+  func.func private @main() attributes {forth.kernel} {
     %alloca = memref.alloca() : memref<256xi64>
     %c0 = arith.constant 0 : index
     return

--- a/test/Pipeline/begin-until.forth
+++ b/test/Pipeline/begin-until.forth
@@ -11,5 +11,6 @@
 \ MID: cf.cond_br
 \ MID: gpu.return
 
-PARAM DATA 4
+\! kernel main
+\! param DATA i64[4]
 10 BEGIN 1 - DUP 0= UNTIL DATA 0 CELLS + !

--- a/test/Pipeline/begin-while-repeat.forth
+++ b/test/Pipeline/begin-while-repeat.forth
@@ -11,5 +11,6 @@
 \ MID: cf.cond_br
 \ MID: gpu.return
 
-PARAM DATA 4
+\! kernel main
+\! param DATA i64[4]
 10 BEGIN DUP 0 > WHILE 1 - REPEAT DATA 0 CELLS + !

--- a/test/Pipeline/control-flow.forth
+++ b/test/Pipeline/control-flow.forth
@@ -12,5 +12,6 @@
 \ MID: cf.cond_br
 \ MID: gpu.return
 
-PARAM DATA 256
+\! kernel main
+\! param DATA i64[256]
 DATA @ 5 > IF DATA @ 1 + DATA ! THEN

--- a/test/Pipeline/do-loop.forth
+++ b/test/Pipeline/do-loop.forth
@@ -11,5 +11,6 @@
 \ MID: cf.cond_br
 \ MID: gpu.return
 
-PARAM DATA 4
+\! kernel main
+\! param DATA i64[4]
 10 0 DO I LOOP DATA 0 CELLS + !

--- a/test/Pipeline/exit.forth
+++ b/test/Pipeline/exit.forth
@@ -1,6 +1,7 @@
 \ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --warpforth-pipeline | %FileCheck %s
 \ CHECK: gpu.binary @warpforth_module
 
-PARAM DATA 4
+\! kernel main
+\! param DATA i64[4]
 : DO-EXIT 1 IF EXIT THEN 42 ;
 DO-EXIT DATA 0 CELLS + !

--- a/test/Pipeline/full-pipeline.forth
+++ b/test/Pipeline/full-pipeline.forth
@@ -14,7 +14,8 @@
 \ MID: llvm.store
 \ MID: gpu.return
 
-PARAM DATA 256
+\! kernel main
+\! param DATA i64[256]
 GLOBAL-ID CELLS DATA + @
 1 +
 GLOBAL-ID CELLS DATA + !

--- a/test/Pipeline/interleaved-control-flow.forth
+++ b/test/Pipeline/interleaved-control-flow.forth
@@ -22,7 +22,8 @@
 \ MID: cf.cond_br
 \ MID: cf.br
 
-PARAM DATA 4
+\! kernel main
+\! param DATA i64[4]
 : multi-while
   BEGIN DUP 10 > WHILE DUP 2 MOD 0= WHILE 1 - REPEAT DROP THEN ;
 : while-until

--- a/test/Pipeline/leave.forth
+++ b/test/Pipeline/leave.forth
@@ -11,5 +11,6 @@
 \ MID: cf.cond_br
 \ MID: gpu.return
 
-PARAM DATA 4
+\! kernel main
+\! param DATA i64[4]
 10 0 DO LEAVE LOOP DATA 0 CELLS + !

--- a/test/Pipeline/matmul-naive.forth
+++ b/test/Pipeline/matmul-naive.forth
@@ -7,9 +7,10 @@
 \ Verify the kernel signature at the memref+gpu stage.
 \ MID: gpu.func @main(%arg0: memref<8xi64> {forth.param_name = "A"}, %arg1: memref<12xi64> {forth.param_name = "B"}, %arg2: memref<6xi64> {forth.param_name = "C"}) kernel
 
-PARAM A 8
-PARAM B 12
-PARAM C 6
+\! kernel main
+\! param A i64[8]
+\! param B i64[12]
+\! param C i64[6]
 
 \ M=2, N=3, K=4. One thread computes C[row, col] where gid = row*N + col.
 GLOBAL-ID

--- a/test/Pipeline/multi-param.forth
+++ b/test/Pipeline/multi-param.forth
@@ -12,8 +12,9 @@
 \ MID: llvm.store
 \ MID: gpu.return
 
-PARAM INPUT 256
-PARAM OUTPUT 256
+\! kernel main
+\! param INPUT i64[256]
+\! param OUTPUT i64[256]
 GLOBAL-ID CELLS INPUT + @
 2 *
 GLOBAL-ID CELLS OUTPUT + !

--- a/test/Pipeline/nested-control-flow.forth
+++ b/test/Pipeline/nested-control-flow.forth
@@ -10,5 +10,6 @@
 \ MID: cf.br
 \ MID: arith.xori
 
-PARAM DATA 4
+\! kernel main
+\! param DATA i64[4]
 3 0 DO 4 0 DO J I + LOOP LOOP DATA 0 CELLS + !

--- a/test/Pipeline/plus-loop-negative.forth
+++ b/test/Pipeline/plus-loop-negative.forth
@@ -3,5 +3,6 @@
 \ Verify that +LOOP with negative step through the full pipeline produces a gpu.binary
 \ CHECK: gpu.binary @warpforth_module
 
-PARAM DATA 4
+\! kernel main
+\! param DATA i64[4]
 0 10 DO I DATA 0 CELLS + ! -1 +LOOP

--- a/test/Pipeline/plus-loop.forth
+++ b/test/Pipeline/plus-loop.forth
@@ -3,5 +3,6 @@
 \ Verify that +LOOP through the full pipeline produces a gpu.binary
 \ CHECK: gpu.binary @warpforth_module
 
-PARAM DATA 4
+\! kernel main
+\! param DATA i64[4]
 10 0 DO I DATA 0 CELLS + ! 2 +LOOP

--- a/test/Pipeline/unloop-exit.forth
+++ b/test/Pipeline/unloop-exit.forth
@@ -1,6 +1,7 @@
 \ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --warpforth-pipeline | %FileCheck %s
 \ CHECK: gpu.binary @warpforth_module
 
-PARAM DATA 4
+\! kernel main
+\! param DATA i64[4]
 : FIND-FIVE  10 0 DO I 5 = IF UNLOOP EXIT THEN LOOP 0 ;
 FIND-FIVE DATA 0 CELLS + !

--- a/test/Translation/Forth/arithmetic-ops.forth
+++ b/test/Translation/Forth/arithmetic-ops.forth
@@ -9,4 +9,5 @@
 \ CHECK: %[[S5:.*]] = forth.mul %[[S4]]
 \ CHECK: %[[S6:.*]] = forth.div %[[S5]]
 \ CHECK: %{{.*}} = forth.mod %[[S6]]
+\! kernel main
 1 2 + - * / MOD

--- a/test/Translation/Forth/basic-literals.forth
+++ b/test/Translation/Forth/basic-literals.forth
@@ -4,4 +4,5 @@
 \ CHECK-NEXT: forth.literal %{{.*}} 42
 \ CHECK-NEXT: forth.literal %{{.*}} -7
 \ CHECK-NEXT: forth.literal %{{.*}} 0
+\! kernel main
 42 -7 0

--- a/test/Translation/Forth/begin-until.forth
+++ b/test/Translation/Forth/begin-until.forth
@@ -14,4 +14,5 @@
 \ CHECK-NEXT:  cf.cond_br %[[FLAG]], ^bb2(%[[PF]] : !forth.stack), ^bb1(%[[PF]] : !forth.stack)
 \ CHECK:     ^bb2(%[[B2:.*]]: !forth.stack):
 \ CHECK-NEXT:  return
+\! kernel main
 10 BEGIN 1 - DUP 0= UNTIL

--- a/test/Translation/Forth/begin-while-repeat.forth
+++ b/test/Translation/Forth/begin-while-repeat.forth
@@ -17,4 +17,5 @@
 \ CHECK-NEXT:  cf.br ^bb1(%[[SUB]] : !forth.stack)
 \ CHECK:     ^bb3(%[[B3:.*]]: !forth.stack):
 \ CHECK-NEXT:  return
+\! kernel main
 10 BEGIN DUP 0 > WHILE 1 - REPEAT

--- a/test/Translation/Forth/bitwise-ops.forth
+++ b/test/Translation/Forth/bitwise-ops.forth
@@ -19,4 +19,5 @@
 \ CHECK: %[[S15:.*]] = forth.literal %[[S14]]
 \ CHECK: %[[S16:.*]] = forth.literal %[[S15]]
 \ CHECK: %{{.*}} = forth.rshift %[[S16]]
+\! kernel main
 3 5 AND 7 8 OR 15 3 XOR 42 NOT 1 4 LSHIFT 256 2 RSHIFT

--- a/test/Translation/Forth/case-insensitive.forth
+++ b/test/Translation/Forth/case-insensitive.forth
@@ -5,4 +5,5 @@
 \ CHECK: forth.drop
 \ CHECK: forth.swap
 \ CHECK: forth.add
+\! kernel main
 1 Dup DROP swap duP +

--- a/test/Translation/Forth/comparison-ops.forth
+++ b/test/Translation/Forth/comparison-ops.forth
@@ -22,4 +22,5 @@
 \ CHECK: %[[S18:.*]] = forth.literal %[[S17]]
 \ CHECK: %[[S19:.*]] = forth.literal %[[S18]]
 \ CHECK: %{{.*}} = forth.ge %[[S19]]
+\! kernel main
 1 2 = 3 4 < 5 6 > 0 0= 7 8 <> 9 10 <= 11 12 >=

--- a/test/Translation/Forth/control-flow.forth
+++ b/test/Translation/Forth/control-flow.forth
@@ -13,6 +13,7 @@
 \ CHECK:     ^bb2(%[[B2:.*]]: !forth.stack):
 \ CHECK-NEXT:  %[[L99:.*]] = forth.literal %[[B2]] 99 : !forth.stack -> !forth.stack
 \ CHECK-NEXT:  cf.br ^bb3(%[[L99]] : !forth.stack)
+\! kernel main
 1 IF 42 ELSE 99 THEN
 
 \ Basic IF/THEN (no ELSE - fallthrough on false)

--- a/test/Translation/Forth/do-loop.forth
+++ b/test/Translation/Forth/do-loop.forth
@@ -28,4 +28,5 @@
 \ CHECK-NEXT:  cf.cond_br %[[CROSSED]], ^bb2(%[[PUSH]] : !forth.stack), ^bb1(%[[PUSH]] : !forth.stack)
 \ CHECK:     ^bb2(%[[B2:.*]]: !forth.stack):
 \ CHECK-NEXT:  return
+\! kernel main
 10 0 DO I LOOP

--- a/test/Translation/Forth/exit-outside-word-error.forth
+++ b/test/Translation/Forth/exit-outside-word-error.forth
@@ -1,3 +1,4 @@
 \ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
 \ CHECK: EXIT outside word definition
+\! kernel main
 EXIT

--- a/test/Translation/Forth/exit.forth
+++ b/test/Translation/Forth/exit.forth
@@ -9,5 +9,6 @@
 \ CHECK: ^[[RET]](%[[R:.*]]: !forth.stack):
 \ CHECK:   return %[[R]] : !forth.stack
 
+\! kernel main
 : EARLY-EXIT 1 IF EXIT THEN 42 ;
 EARLY-EXIT

--- a/test/Translation/Forth/gpu-indexing.forth
+++ b/test/Translation/Forth/gpu-indexing.forth
@@ -13,6 +13,7 @@
 \ CHECK: forth.grid_dim_y
 \ CHECK: forth.grid_dim_z
 \ CHECK: forth.global_id
+\! kernel main
 TID-X TID-Y TID-Z
 BID-X BID-Y BID-Z
 BDIM-X BDIM-Y BDIM-Z

--- a/test/Translation/Forth/header-directive-after-code-error.forth
+++ b/test/Translation/Forth/header-directive-after-code-error.forth
@@ -1,0 +1,6 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: header directive must appear before any code
+\! kernel main
+\! param A i64[4]
+A @
+\! param B i64[4]

--- a/test/Translation/Forth/header-duplicate-kernel-error.forth
+++ b/test/Translation/Forth/header-duplicate-kernel-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: duplicate \! kernel directive
+\! kernel main
+\! kernel other

--- a/test/Translation/Forth/header-duplicate-param-error.forth
+++ b/test/Translation/Forth/header-duplicate-param-error.forth
@@ -1,0 +1,5 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: duplicate parameter name: A
+\! kernel main
+\! param A i64[4]
+\! param A i64[8]

--- a/test/Translation/Forth/header-missing-kernel-error.forth
+++ b/test/Translation/Forth/header-missing-kernel-error.forth
@@ -1,0 +1,3 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: \! kernel <name> is required
+1 2 +

--- a/test/Translation/Forth/header-unknown-directive-error.forth
+++ b/test/Translation/Forth/header-unknown-directive-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: unknown header directive: BOGUS
+\! kernel main
+\! bogus foo bar

--- a/test/Translation/Forth/interleaved-control-flow.forth
+++ b/test/Translation/Forth/interleaved-control-flow.forth
@@ -44,6 +44,7 @@
 \ CHECK-NEXT:  %{{.*}} = forth.drop
 \ CHECK-NEXT:  cf.br ^bb3
 
+\! kernel main
 : multi-while
   BEGIN DUP 10 > WHILE DUP 2 MOD 0= WHILE 1 - REPEAT DROP THEN ;
 

--- a/test/Translation/Forth/leave-conditional.forth
+++ b/test/Translation/Forth/leave-conditional.forth
@@ -28,6 +28,7 @@
 \ CHECK:     ^bb[[DEAD]](%{{.*}}: !forth.stack):
 \ CHECK:       cf.br ^bb[[JOIN]]
 
+\! kernel main
 10 0 DO
   I 5 = IF LEAVE THEN
   1 DROP

--- a/test/Translation/Forth/leave.forth
+++ b/test/Translation/Forth/leave.forth
@@ -12,4 +12,5 @@
 \ CHECK:     ^bb[[EXIT]](%[[B3:.*]]: !forth.stack):
 \ CHECK-NEXT:  return
 
+\! kernel main
 10 0 DO LEAVE LOOP

--- a/test/Translation/Forth/loop-index-depth-error.forth
+++ b/test/Translation/Forth/loop-index-depth-error.forth
@@ -1,3 +1,4 @@
 \ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
 \ CHECK: 'J' requires 2 nested DO/LOOP(s)
+\! kernel main
 10 0 DO J LOOP

--- a/test/Translation/Forth/memory-ops.forth
+++ b/test/Translation/Forth/memory-ops.forth
@@ -9,5 +9,6 @@
 \ Test CELLS produces literal 8 + mul
 \ CHECK: forth.literal %{{.*}} 8
 \ CHECK-NEXT: forth.mul
+\! kernel main
 1 @ 2 3 !
 4 CELLS

--- a/test/Translation/Forth/name-mangling.forth
+++ b/test/Translation/Forth/name-mangling.forth
@@ -9,6 +9,7 @@
 \ Leading digit gets underscore prefix
 \ CHECK: func.func private @_2START
 
+\! kernel main
 : MY-WORD 1 ;
 : UNDER_SCORE 2 ;
 : 2START 3 ;

--- a/test/Translation/Forth/nested-control-flow.forth
+++ b/test/Translation/Forth/nested-control-flow.forth
@@ -9,6 +9,7 @@
 \ CHECK-NEXT:  %[[L2:.*]] = forth.literal %[[B1]] 2 : !forth.stack -> !forth.stack
 \ CHECK-NEXT:  %[[PF2:.*]], %[[FL2:.*]] = forth.pop_flag %[[L2]] : !forth.stack -> !forth.stack, i1
 \ CHECK-NEXT:  cf.cond_br %[[FL2]], ^bb3(%[[PF2]] : !forth.stack), ^bb4(%[[PF2]] : !forth.stack)
+\! kernel main
 1 IF 2 IF 3 THEN THEN
 
 \ === IF inside DO ===

--- a/test/Translation/Forth/param-declarations.forth
+++ b/test/Translation/Forth/param-declarations.forth
@@ -4,6 +4,7 @@
 \ CHECK: func.func private @main(%arg0: memref<256xi64> {forth.param_name = "DATA"}, %arg1: memref<128xi64> {forth.param_name = "WEIGHTS"})
 \ CHECK: forth.param_ref %{{.*}} "DATA"
 \ CHECK: forth.param_ref %{{.*}} "WEIGHTS"
-PARAM DATA 256
-PARAM WEIGHTS 128
+\! kernel main
+\! param DATA i64[256]
+\! param WEIGHTS i64[128]
 DATA WEIGHTS

--- a/test/Translation/Forth/param-ref-in-word-error.forth
+++ b/test/Translation/Forth/param-ref-in-word-error.forth
@@ -1,5 +1,6 @@
 \ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
 \ CHECK: parameter 'DATA' cannot be referenced inside a word definition
-PARAM DATA 256
+\! kernel main
+\! param DATA i64[256]
 : BAD-WORD DATA @ ;
 BAD-WORD

--- a/test/Translation/Forth/plus-loop-negative.forth
+++ b/test/Translation/Forth/plus-loop-negative.forth
@@ -21,4 +21,5 @@
 \ CHECK-NEXT:  cf.cond_br %[[CROSSED]], ^bb2(%[[POP_S]] : !forth.stack), ^bb1(%[[POP_S]] : !forth.stack)
 \ CHECK:     ^bb2(%{{.*}}: !forth.stack):
 \ CHECK-NEXT:  return
+\! kernel main
 0 10 DO -1 +LOOP

--- a/test/Translation/Forth/plus-loop-without-do-error.forth
+++ b/test/Translation/Forth/plus-loop-without-do-error.forth
@@ -1,3 +1,4 @@
 \ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
 \ CHECK: +LOOP without matching DO
+\! kernel main
 +LOOP

--- a/test/Translation/Forth/plus-loop.forth
+++ b/test/Translation/Forth/plus-loop.forth
@@ -26,4 +26,5 @@
 \ CHECK-NEXT:  cf.cond_br %[[CROSSED]], ^bb2(%[[POP_S]] : !forth.stack), ^bb1(%[[POP_S]] : !forth.stack)
 \ CHECK:     ^bb2(%[[B2:.*]]: !forth.stack):
 \ CHECK-NEXT:  return
+\! kernel main
 10 0 DO 2 +LOOP

--- a/test/Translation/Forth/scalar-param.forth
+++ b/test/Translation/Forth/scalar-param.forth
@@ -1,0 +1,8 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %FileCheck %s
+
+\ Verify scalar param uses i64 argument type.
+\ CHECK: func.func private @main(%arg0: i64 {forth.param_name = "SCALE"})
+\ CHECK: forth.param_ref %{{.*}} "SCALE"
+\! kernel main
+\! param SCALE i64
+SCALE

--- a/test/Translation/Forth/stack-ops.forth
+++ b/test/Translation/Forth/stack-ops.forth
@@ -10,4 +10,5 @@
 \ CHECK: forth.tuck %{{.*}} : !forth.stack -> !forth.stack
 \ CHECK: forth.pick %{{.*}} : !forth.stack -> !forth.stack
 \ CHECK: forth.roll %{{.*}} : !forth.stack -> !forth.stack
+\! kernel main
 1 DUP DROP SWAP OVER ROT NIP TUCK PICK ROLL

--- a/test/Translation/Forth/unloop-exit.forth
+++ b/test/Translation/Forth/unloop-exit.forth
@@ -15,5 +15,6 @@
 \ CHECK: ^bb[[#RET]](%[[R:.*]]: !forth.stack):
 \ CHECK: return %[[R]] : !forth.stack
 
+\! kernel main
 : FIND-FIVE  10 0 DO I 5 = IF UNLOOP EXIT THEN LOOP 0 ;
 FIND-FIVE

--- a/test/Translation/Forth/unloop-without-do-error.forth
+++ b/test/Translation/Forth/unloop-without-do-error.forth
@@ -1,3 +1,4 @@
 \ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
 \ CHECK: UNLOOP without matching DO
+\! kernel main
 UNLOOP

--- a/test/Translation/Forth/word-definitions.forth
+++ b/test/Translation/Forth/word-definitions.forth
@@ -7,5 +7,6 @@
 \ CHECK: }
 \ CHECK: func.func private @main()
 \ CHECK:   call @DOUBLE(%{{.*}}) : (!forth.stack) -> !forth.stack
+\! kernel main
 : DOUBLE DUP + ;
 5 DOUBLE


### PR DESCRIPTION
## Summary
- Replace `PARAM <name> <size>` with structured `\!` header block (`\! kernel`, `\! param`, `\! shared` directives)
- Support scalar params (`i64`) in addition to array params (`i64[N]`)
- Detect kernels via `forth.kernel` attribute instead of hardcoded name matching
- Make `--kernel` flag required in warpforth-runner

## Test plan
- [x] All 61 lit tests pass (`check-warpforth`)
- [x] C++ formatting clean (`cmake --build build --target format`)
- [x] Python lint/format clean (`ruff check` + `ruff format --check`)
- [x] GPU end-to-end tests (`pytest -v -m gpu`)

Addresses #30