### PR TITLE
feat: support scalar kernel params in runner and test infra

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Requires MLIR/LLVM with `MLIR_DIR` and `LLVM_DIR` configured in CMake.
   ./build/bin/warpforth-translate --mlir-to-ptx > kernel.ptx
 
 # Execute PTX on GPU
-./warpforth-runner kernel.ptx --param 1,2,3 --param 0,0,0,0 --output-param 1 --output-count 5
+./warpforth-runner kernel.ptx --param i64[]:1,2,3 --param i64:42 --output-param 0 --output-count 3
 ```
 
 ## Adding New Operations

--- a/gpu_test/conftest.py
+++ b/gpu_test/conftest.py
@@ -384,8 +384,11 @@ class KernelRunner:
 
         params = params or {}
 
-        # Validate output_param is not a scalar
-        if output_param < len(decls) and not decls[output_param].is_array:
+        # Validate output_param
+        if output_param < 0 or output_param >= len(decls):
+            msg = f"output_param {output_param} out of range (have {len(decls)} params)"
+            raise ValueError(msg)
+        if not decls[output_param].is_array:
             name = decls[output_param].name
             msg = f"output_param {output_param} ('{name}') is a scalar and cannot be read back"
             raise ValueError(msg)

--- a/gpu_test/test_kernels.py
+++ b/gpu_test/test_kernels.py
@@ -280,6 +280,26 @@ def test_multi_param(kernel_runner: KernelRunner) -> None:
     assert result == [20, 40, 60, 80]
 
 
+def test_scalar_param(kernel_runner: KernelRunner) -> None:
+    """Scalar + array params: each thread multiplies INPUT[i] by SCALE, writes OUTPUT[i]."""
+    result = kernel_runner.run(
+        forth_source=(
+            "\\! kernel main\n\\! param SCALE i64\n"
+            "\\! param INPUT i64[4]\n"
+            "\\! param OUTPUT i64[4]\n"
+            "GLOBAL-ID\n"
+            "DUP CELLS INPUT + @\n"
+            "SCALE *\n"
+            "SWAP CELLS OUTPUT + !"
+        ),
+        params={"SCALE": 3, "INPUT": [10, 20, 30, 40]},
+        block=(4, 1, 1),
+        output_param=2,
+        output_count=4,
+    )
+    assert result == [30, 60, 90, 120]
+
+
 # --- Matmul ---
 
 

--- a/test/Pipeline/scalar-param.forth
+++ b/test/Pipeline/scalar-param.forth
@@ -5,7 +5,10 @@
 \ CHECK: gpu.binary @warpforth_module
 
 \ Verify scalar becomes i64 arg, array becomes memref
-\ MID: gpu.func @main(%arg0: i64 {forth.param_name = "SCALE"}, %arg1: memref<256xi64> {forth.param_name = "DATA"}) kernel
+\ MID: gpu.func @main(
+\ MID-SAME: i64 {forth.param_name = "SCALE"}
+\ MID-SAME: memref<256xi64> {forth.param_name = "DATA"}
+\ MID-SAME: kernel
 \ MID: gpu.return
 
 \! kernel main

--- a/test/Pipeline/scalar-param.forth
+++ b/test/Pipeline/scalar-param.forth
@@ -1,0 +1,17 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --warpforth-pipeline | %FileCheck %s
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --convert-forth-to-memref --convert-forth-to-gpu | %FileCheck %s --check-prefix=MID
+
+\ Verify mixed scalar + array params survive the full pipeline
+\ CHECK: gpu.binary @warpforth_module
+
+\ Verify scalar becomes i64 arg, array becomes memref
+\ MID: gpu.func @main(%arg0: i64 {forth.param_name = "SCALE"}, %arg1: memref<256xi64> {forth.param_name = "DATA"}) kernel
+\ MID: gpu.return
+
+\! kernel main
+\! param SCALE i64
+\! param DATA i64[256]
+GLOBAL-ID
+DUP CELLS DATA + @
+SCALE *
+SWAP CELLS DATA + !

--- a/tools/warpforth-runner/warpforth-runner.cpp
+++ b/tools/warpforth-runner/warpforth-runner.cpp
@@ -69,6 +69,11 @@ static Param parseParam(const char *s) {
   std::string typePrefix = input.substr(0, colonPos);
   std::string valueStr = input.substr(colonPos + 1);
 
+  if (valueStr.empty()) {
+    fprintf(stderr, "Error: --param requires at least one value, got: %s\n", s);
+    exit(1);
+  }
+
   // Determine kind from type prefix
   if (typePrefix == "i64[]") {
     p.kind = ParamKind::Array;
@@ -228,8 +233,8 @@ int main(int argc, char **argv) {
   std::vector<void *> kernelArgs(params.size());
   for (size_t i = 0; i < params.size(); ++i) {
     kernelArgs[i] = (params[i].kind == ParamKind::Array)
-                        ? (void *)&devicePtrs[i]
-                        : (void *)&scalarValues[i];
+                        ? static_cast<void *>(&devicePtrs[i])
+                        : static_cast<void *>(&scalarValues[i]);
   }
 
   // Launch kernel


### PR DESCRIPTION
## Summary
- Add typed `--param` format to `warpforth-runner`: `i64:42` (scalar) and `i64[]:1,2,3` (array)
- Update `conftest.py` to parse scalar param declarations and pass them with the typed format
- Add pipeline test (`scalar-param.forth`) and GPU test (`test_scalar_param`) for mixed scalar+array kernels

Closes #32