### PR TITLE
feat: add shared memory support via \! shared header directive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ uv run ruff format gpu_test/
 - **Operations**: All take stack as input and produce stack as output (except `forth.stack`)
 - **Supported Words**: literals, `DUP DROP SWAP OVER ROT NIP TUCK PICK ROLL`, `+ - * / MOD`, `AND OR XOR NOT LSHIFT RSHIFT`, `= < > <> <= >= 0=`, `@ !`, `CELLS`, `IF ELSE THEN`, `BEGIN UNTIL`, `BEGIN WHILE REPEAT`, `DO LOOP +LOOP I J K`, `LEAVE UNLOOP EXIT`, `TID-X/Y/Z BID-X/Y/Z BDIM-X/Y/Z GDIM-X/Y/Z GLOBAL-ID` (GPU indexing).
 - **Kernel Parameters**: Declared in the `\!` header. `\! kernel <name>` is required and must appear first. `\! param <name> i64[<N>]` becomes a `memref<Nxi64>` argument; `\! param <name> i64` becomes an `i64` argument. Using a param name in code emits `forth.param_ref` (arrays push address; scalars push value).
+- **Shared Memory**: `\! shared <name> i64[<N>]` declares GPU shared (workgroup) memory. Emits a tagged `memref.alloca` at kernel entry; ForthToGPU converts it to a `gpu.func` workgroup attribution (`memref<Nxi64, #gpu.address_space<workgroup>>`). Using the shared name in code pushes its base address onto the stack. Cannot be referenced inside word definitions.
 - **Conversion**: `!forth.stack` → `memref<256xi64>` with explicit stack pointer
 - **GPU**: Functions wrapped in `gpu.module`, `main` gets `gpu.kernel` attribute, configured with bare pointers for NVVM conversion
 - **User-defined Words**: Modeled as `func.func` with signature `(!forth.stack) -> !forth.stack`, called via `func.call`

--- a/lib/Conversion/ForthToGPU/ForthToGPU.cpp
+++ b/lib/Conversion/ForthToGPU/ForthToGPU.cpp
@@ -158,9 +158,9 @@ private:
     }
 
     // Clone ops from each source block into the corresponding destination
-    // block, with three transformations:
-    // - func.return → gpu.return
-    // - shared memref.alloca → gpu.func workgroup attribution
+    // block, with two transformations:
+    // - func.return -> gpu.return
+    // - shared memref.alloca -> gpu.func workgroup attribution
     auto *ctx = funcOp.getContext();
     for (auto [srcBlock, dstBlock] :
          llvm::zip(funcOp.getBody(), gpuFunc.getBody())) {

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.h
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.h
@@ -26,7 +26,6 @@ struct ParamDecl {
 };
 
 /// A declared shared memory region: `shared <name> <type>`.
-/// TODO: Not yet consumed — scaffolding for shared memory support.
 struct SharedDecl {
   std::string name;
   bool isArray = false;

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.h
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.h
@@ -10,6 +10,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/ADT/StringMap.h"
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -92,6 +93,7 @@ private:
   std::unordered_set<std::string> wordDefs;
   std::vector<ParamDecl> paramDecls;
   std::vector<SharedDecl> sharedDecls;
+  llvm::StringMap<Value> sharedAllocs;
   std::string kernelName;
   const char *headerEndPtr = nullptr;
   bool inWordDefinition = false;

--- a/test/Conversion/ForthToGPU/shared-memory.mlir
+++ b/test/Conversion/ForthToGPU/shared-memory.mlir
@@ -1,0 +1,18 @@
+// RUN: %warpforth-opt --convert-forth-to-gpu %s | %FileCheck %s
+
+// CHECK: gpu.module @warpforth_module
+// CHECK: gpu.func @main(%arg0: memref<256xi64> {forth.param_name = "DATA"})
+// CHECK-SAME: workgroup(%{{.*}}: memref<256xi64, #gpu.address_space<workgroup>>)
+// CHECK-SAME: kernel
+// CHECK-NOT: memref.alloca() {forth.shared_name
+// CHECK: memref.extract_aligned_pointer_as_index %{{.*}} : memref<256xi64, #gpu.address_space<workgroup>>
+// CHECK: gpu.return
+
+module {
+  func.func private @main(%arg0: memref<256xi64> {forth.param_name = "DATA"}) attributes {forth.kernel} {
+    %alloca = memref.alloca() {forth.shared_name = "SCRATCH"} : memref<256xi64>
+    %ptr = memref.extract_aligned_pointer_as_index %alloca : memref<256xi64> -> index
+    %c0 = arith.constant 0 : index
+    return
+  }
+}

--- a/test/Pipeline/shared-memory.forth
+++ b/test/Pipeline/shared-memory.forth
@@ -1,0 +1,21 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --warpforth-pipeline | %FileCheck %s
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --convert-forth-to-memref --convert-forth-to-gpu | %FileCheck %s --check-prefix=MID
+
+\ Verify that shared memory through the full pipeline produces a gpu.binary
+\ CHECK: gpu.binary @warpforth_module
+
+\ Verify intermediate MLIR structure: shared alloca becomes workgroup attribution
+\ MID: gpu.module @warpforth_module
+\ MID: gpu.func @main(%arg0: memref<256xi64> {forth.param_name = "DATA"})
+\ MID-SAME: workgroup(%{{.*}}: memref<256xi64, #gpu.address_space<workgroup>>)
+\ MID-SAME: kernel
+\ MID: memref.extract_aligned_pointer_as_index %{{.*}} : memref<256xi64, #gpu.address_space<workgroup>>
+\ MID: llvm.store
+\ MID: gpu.return
+
+\! kernel main
+\! param DATA i64[256]
+\! shared SCRATCH i64[256]
+GLOBAL-ID CELLS SCRATCH + !
+GLOBAL-ID CELLS SCRATCH + @
+GLOBAL-ID CELLS DATA + !

--- a/test/Translation/Forth/header-duplicate-param-error.forth
+++ b/test/Translation/Forth/header-duplicate-param-error.forth
@@ -1,5 +1,5 @@
 \ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
-\ CHECK: duplicate parameter name: A
+\ CHECK: duplicate name: A (already declared as param)
 \! kernel main
 \! param A i64[4]
 \! param A i64[8]

--- a/test/Translation/Forth/header-shared-param-duplicate-error.forth
+++ b/test/Translation/Forth/header-shared-param-duplicate-error.forth
@@ -1,0 +1,5 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: duplicate name: A (already declared as param)
+\! kernel main
+\! param A i64[4]
+\! shared A i64[8]

--- a/test/Translation/Forth/shared-declarations.forth
+++ b/test/Translation/Forth/shared-declarations.forth
@@ -1,0 +1,12 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %FileCheck %s
+
+\ Verify shared memory declarations produce tagged alloca and pointer push sequence
+\ CHECK: func.func private @main(%arg0: memref<256xi64> {forth.param_name = "DATA"})
+\ CHECK: memref.alloca() {forth.shared_name = "SCRATCH"} : memref<256xi64>
+\ CHECK: memref.extract_aligned_pointer_as_index
+\ CHECK: arith.index_cast
+\ CHECK: forth.push_value
+\! kernel main
+\! param DATA i64[256]
+\! shared SCRATCH i64[256]
+SCRATCH

--- a/test/Translation/Forth/shared-ref-in-word-error.forth
+++ b/test/Translation/Forth/shared-ref-in-word-error.forth
@@ -1,0 +1,6 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: shared memory 'SCRATCH' cannot be referenced inside a word definition
+\! kernel main
+\! shared SCRATCH i64[256]
+: BAD-WORD SCRATCH @ ;
+BAD-WORD


### PR DESCRIPTION
Closes #4

## Summary
- Add `\! shared <name> i64[<N>]` header directive for declaring GPU shared (workgroup) memory
- ForthToMLIR emits tagged `memref.alloca` at kernel entry; using the shared name pushes its base address onto the stack
- ForthToGPU converts tagged allocas to `gpu.func` workgroup attributions (`memref<Nxi64, #gpu.address_space<workgroup>>`)

## Test plan
- [x] Translation test: shared alloca emission with `forth.shared_name` attr and pointer push sequence
- [x] Translation error test: shared name rejected inside word definitions
- [x] Translation error test: param/shared cross-namespace name collision
- [x] ForthToGPU conversion test: alloca replaced by workgroup attribution
- [x] End-to-end pipeline test: full pipeline produces `gpu.binary`, intermediate check for workgroup attribution
- [x] All 72 tests pass