### PR TITLE
Add BARRIER word for GPU thread synchronization

### DIFF
--- a/include/warpforth/Dialect/Forth/ForthOps.td
+++ b/include/warpforth/Dialect/Forth/ForthOps.td
@@ -385,6 +385,20 @@ def Forth_GlobalIdOp : Forth_StackOpBase<"global_id"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Synchronization operations.
+//===----------------------------------------------------------------------===//
+
+def Forth_BarrierOp : Forth_Op<"barrier", []> {
+  let summary = "GPU thread synchronization barrier";
+  let description = [{
+    Synchronizes all threads in a block.
+    Corresponds to CUDA's __syncthreads().
+    Forth semantics: ( -- )
+  }];
+  let assemblyFormat = "attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
 // Comparison operations.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
+++ b/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
@@ -976,8 +976,9 @@ struct ConvertForthToMemRefPass
     target.addLegalDialect<memref::MemRefDialect, arith::ArithDialect,
                            LLVM::LLVMDialect, cf::ControlFlowDialect>();
 
-    // Mark IntrinsicOp as legal (to be lowered later)
+    // Mark IntrinsicOp and BarrierOp as legal (to be lowered later)
     target.addLegalOp<forth::IntrinsicOp>();
+    target.addLegalOp<forth::BarrierOp>();
 
     // Use dynamic legality for func operations to ensure they're properly
     // converted

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
@@ -526,6 +526,9 @@ Value ForthParser::emitOperation(StringRef word, Value inputStack,
   } else if (word == "GLOBAL-ID") {
     return builder.create<forth::GlobalIdOp>(loc, stackType, inputStack)
         .getResult();
+  } else if (word == "BARRIER") {
+    builder.create<forth::BarrierOp>(loc);
+    return inputStack;
   } else if (word == "=") {
     return builder.create<forth::EqOp>(loc, stackType, inputStack).getResult();
   } else if (word == "<") {

--- a/test/Conversion/ForthToMemRef/barrier.mlir
+++ b/test/Conversion/ForthToMemRef/barrier.mlir
@@ -1,0 +1,9 @@
+// RUN: %warpforth-opt --convert-forth-to-memref %s | %FileCheck %s
+// CHECK-LABEL: func.func private @main
+// CHECK: forth.barrier
+func.func private @main() {
+  %0 = forth.stack !forth.stack
+  forth.barrier
+  forth.drop %0 : !forth.stack -> !forth.stack
+  return
+}

--- a/test/Pipeline/barrier.forth
+++ b/test/Pipeline/barrier.forth
@@ -1,0 +1,10 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --warpforth-pipeline | %FileCheck %s
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --convert-forth-to-memref --convert-forth-to-gpu | %FileCheck %s --check-prefix=MID
+\ CHECK: gpu.binary @warpforth_module
+\ MID: gpu.func @main
+\ MID: gpu.barrier
+\ MID: gpu.return
+\! kernel main
+\! param DATA i64[256]
+\! shared SCRATCH i64[256]
+GLOBAL-ID CELLS SCRATCH + @ BARRIER GLOBAL-ID CELLS DATA + !

--- a/test/Translation/Forth/barrier.forth
+++ b/test/Translation/Forth/barrier.forth
@@ -1,0 +1,5 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %FileCheck %s
+\ CHECK: forth.barrier
+\! kernel main
+\! param DATA i64[256]
+GLOBAL-ID CELLS DATA + @ BARRIER DROP


### PR DESCRIPTION
## Summary

- Add `BARRIER` word (`( -- )`) that lowers through `forth.barrier` → `gpu.barrier` (`__syncthreads`)
- Stackless op with no `Pure` trait to prevent elimination/reordering
- Passes through ForthToMemRef unchanged, converted in ForthToGPU

## Test plan

- [x] `test/Translation/Forth/barrier.forth` — Forth → MLIR emission
- [x] `test/Conversion/ForthToMemRef/barrier.mlir` — survives stack lowering
- [x] `test/Pipeline/barrier.forth` — full pipeline to `gpu.binary`

Closes #5