### PR TITLE
feat: split global/shared memory words with S@/S!

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,9 @@ uv run ruff format gpu_test/
 
 - **Stack Type**: `!forth.stack` - untyped stack, programmer ensures type safety
 - **Operations**: All take stack as input and produce stack as output (except `forth.stack`)
-- **Supported Words**: literals, `DUP DROP SWAP OVER ROT NIP TUCK PICK ROLL`, `+ - * / MOD`, `AND OR XOR NOT LSHIFT RSHIFT`, `= < > <> <= >= 0=`, `@ !`, `CELLS`, `IF ELSE THEN`, `BEGIN UNTIL`, `BEGIN WHILE REPEAT`, `DO LOOP +LOOP I J K`, `LEAVE UNLOOP EXIT`, `TID-X/Y/Z BID-X/Y/Z BDIM-X/Y/Z GDIM-X/Y/Z GLOBAL-ID` (GPU indexing).
+- **Supported Words**: literals, `DUP DROP SWAP OVER ROT NIP TUCK PICK ROLL`, `+ - * / MOD`, `AND OR XOR NOT LSHIFT RSHIFT`, `= < > <> <= >= 0=`, `@ !` (global memory), `S@ S!` (shared memory), `CELLS`, `IF ELSE THEN`, `BEGIN UNTIL`, `BEGIN WHILE REPEAT`, `DO LOOP +LOOP I J K`, `LEAVE UNLOOP EXIT`, `TID-X/Y/Z BID-X/Y/Z BDIM-X/Y/Z GDIM-X/Y/Z GLOBAL-ID` (GPU indexing).
 - **Kernel Parameters**: Declared in the `\!` header. `\! kernel <name>` is required and must appear first. `\! param <name> i64[<N>]` becomes a `memref<Nxi64>` argument; `\! param <name> i64` becomes an `i64` argument. Using a param name in code emits `forth.param_ref` (arrays push address; scalars push value).
-- **Shared Memory**: `\! shared <name> i64[<N>]` declares GPU shared (workgroup) memory. Emits a tagged `memref.alloca` at kernel entry; ForthToGPU converts it to a `gpu.func` workgroup attribution (`memref<Nxi64, #gpu.address_space<workgroup>>`). Using the shared name in code pushes its base address onto the stack. Cannot be referenced inside word definitions.
+- **Shared Memory**: `\! shared <name> i64[<N>]` declares GPU shared (workgroup) memory. Emits a tagged `memref.alloca` at kernel entry; ForthToGPU converts it to a `gpu.func` workgroup attribution (`memref<Nxi64, #gpu.address_space<workgroup>>`). Using the shared name in code pushes its base address onto the stack. Use `S@`/`S!` for shared accesses. Cannot be referenced inside word definitions.
 - **Conversion**: `!forth.stack` → `memref<256xi64>` with explicit stack pointer
 - **GPU**: Functions wrapped in `gpu.module`, `main` gets `gpu.kernel` attribute, configured with bare pointers for NVVM conversion
 - **User-defined Words**: Modeled as `func.func` with signature `(!forth.stack) -> !forth.stack`, called via `func.call`

--- a/include/warpforth/Dialect/Forth/ForthOps.td
+++ b/include/warpforth/Dialect/Forth/ForthOps.td
@@ -250,6 +250,24 @@ def Forth_StoreOp : Forth_StackOpBase<"store"> {
   }];
 }
 
+def Forth_SharedLoadOp : Forth_StackOpBase<"shared_load"> {
+  let summary = "Load value from shared memory buffer";
+  let description = [{
+    Pops an address from the stack, loads a value from shared/workgroup memory at
+    that address, and pushes the loaded value onto the stack.
+    Forth semantics: ( addr -- value )
+  }];
+}
+
+def Forth_SharedStoreOp : Forth_StackOpBase<"shared_store"> {
+  let summary = "Store value to shared memory buffer";
+  let description = [{
+    Pops an address and value from the stack, stores the value to shared/workgroup
+    memory at the specified address.
+    Forth semantics: ( x addr -- )
+  }];
+}
+
 def Forth_ParamRefOp : Forth_Op<"param_ref", [Pure]> {
   let summary = "Push kernel parameter address onto stack";
   let description = [{

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
@@ -487,6 +487,12 @@ Value ForthParser::emitOperation(StringRef word, Value inputStack,
   } else if (word == "!") {
     return builder.create<forth::StoreOp>(loc, stackType, inputStack)
         .getResult();
+  } else if (word == "S@") {
+    return builder.create<forth::SharedLoadOp>(loc, stackType, inputStack)
+        .getResult();
+  } else if (word == "S!") {
+    return builder.create<forth::SharedStoreOp>(loc, stackType, inputStack)
+        .getResult();
   } else if (word == "TID-X") {
     return builder.create<forth::ThreadIdXOp>(loc, stackType, inputStack)
         .getResult();

--- a/test/Conversion/ForthToMemRef/memory-ops.mlir
+++ b/test/Conversion/ForthToMemRef/memory-ops.mlir
@@ -15,6 +15,14 @@
 // CHECK: llvm.inttoptr %{{.*}} : i64 to !llvm.ptr
 // CHECK: llvm.store %{{.*}}, %{{.*}} : i64, !llvm.ptr
 
+// shared load (S@): pop address, inttoptr shared addrspace, llvm.load
+// CHECK: llvm.inttoptr %{{.*}} : i64 to !llvm.ptr<{{[1-9][0-9]*}}>
+// CHECK: llvm.load %{{.*}} : !llvm.ptr<{{[1-9][0-9]*}}> -> i64
+
+// shared store (S!): pop address + value, inttoptr shared addrspace, llvm.store
+// CHECK: llvm.inttoptr %{{.*}} : i64 to !llvm.ptr<{{[1-9][0-9]*}}>
+// CHECK: llvm.store %{{.*}}, %{{.*}} : i64, !llvm.ptr<{{[1-9][0-9]*}}>
+
 module {
   func.func private @main() {
     %0 = forth.stack !forth.stack
@@ -23,6 +31,11 @@ module {
     %3 = forth.literal %2 42 : !forth.stack -> !forth.stack
     %4 = forth.literal %3 100 : !forth.stack -> !forth.stack
     %5 = forth.store %4 : !forth.stack -> !forth.stack
+    %6 = forth.literal %5 2 : !forth.stack -> !forth.stack
+    %7 = forth.shared_load %6 : !forth.stack -> !forth.stack
+    %8 = forth.literal %7 9 : !forth.stack -> !forth.stack
+    %9 = forth.literal %8 3 : !forth.stack -> !forth.stack
+    %10 = forth.shared_store %9 : !forth.stack -> !forth.stack
     return
   }
 }

--- a/test/Translation/Forth/memory-ops.forth
+++ b/test/Translation/Forth/memory-ops.forth
@@ -6,9 +6,15 @@
 \ Test ! produces forth.store
 \ CHECK: forth.store %{{.*}} : !forth.stack -> !forth.stack
 
+\ Test S@ produces forth.shared_load
+\ CHECK: forth.shared_load %{{.*}} : !forth.stack -> !forth.stack
+
+\ Test S! produces forth.shared_store
+\ CHECK: forth.shared_store %{{.*}} : !forth.stack -> !forth.stack
+
 \ Test CELLS produces literal 8 + mul
 \ CHECK: forth.literal %{{.*}} 8
 \ CHECK-NEXT: forth.mul
 \! kernel main
-1 @ 2 3 !
+1 @ 2 3 ! 4 S@ 5 6 S!
 4 CELLS


### PR DESCRIPTION
## Summary
- add `S@` and `S!` words for explicit shared-memory load/store while keeping `@`/`!` for global memory
- add new dialect ops and parser mappings (`forth.shared_load` / `forth.shared_store`)
- lower shared memory ops through workgroup address-space pointers using `gpu::AddressSpace::Workgroup`
- update translation/conversion tests for the new words and shared address-space lowering
- update tiled matmul GPU test to use `S@`/`S!`

## Test plan
- [x] `cmake --build build --target format`
- [x] `uv run ruff check gpu_test/`
- [x] `cmake --build build --target check-warpforth`

Closes #36
