### PR TITLE
fix(conversion): lower shared S@/S! to NVVM shared address space

### DIFF
--- a/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
+++ b/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"
@@ -28,8 +29,9 @@ namespace {
 
 // Stack configuration constants
 constexpr int64_t kStackSize = 256;
+// NVPTX shared memory address space for LLVM ptr types.
 constexpr unsigned kWorkgroupAddressSpace =
-    static_cast<unsigned>(gpu::AddressSpace::Workgroup);
+    static_cast<unsigned>(NVVM::kSharedMemorySpace);
 
 /// Type converter for forth.stack -> memref + index
 class ForthToMemRefTypeConverter : public TypeConverter {

--- a/test/Conversion/ForthToMemRef/memory-ops.mlir
+++ b/test/Conversion/ForthToMemRef/memory-ops.mlir
@@ -16,12 +16,12 @@
 // CHECK: llvm.store %{{.*}}, %{{.*}} : i64, !llvm.ptr
 
 // shared load (S@): pop address, inttoptr shared addrspace, llvm.load
-// CHECK: llvm.inttoptr %{{.*}} : i64 to !llvm.ptr<{{[1-9][0-9]*}}>
-// CHECK: llvm.load %{{.*}} : !llvm.ptr<{{[1-9][0-9]*}}> -> i64
+// CHECK: llvm.inttoptr %{{.*}} : i64 to !llvm.ptr<3>
+// CHECK: llvm.load %{{.*}} : !llvm.ptr<3> -> i64
 
 // shared store (S!): pop address + value, inttoptr shared addrspace, llvm.store
-// CHECK: llvm.inttoptr %{{.*}} : i64 to !llvm.ptr<{{[1-9][0-9]*}}>
-// CHECK: llvm.store %{{.*}}, %{{.*}} : i64, !llvm.ptr<{{[1-9][0-9]*}}>
+// CHECK: llvm.inttoptr %{{.*}} : i64 to !llvm.ptr<3>
+// CHECK: llvm.store %{{.*}}, %{{.*}} : i64, !llvm.ptr<3>
 
 module {
   func.func private @main() {


### PR DESCRIPTION
## Summary
- fix shared-memory lowering for `S@`/`S!` by using NVVM shared address-space pointers
- replace hardcoded pointer address space with `NVVM::kSharedMemorySpace` in `ForthToMemRef`
- tighten `memory-ops` conversion test to require `!llvm.ptr<3>` for shared load/store lowering
- this makes generated PTX use `ld.shared`/`st.shared` for tiled matmul shared buffers, avoiding illegal memory access

## Test plan
- [x] `cmake --build build --target format`
- [x] `cmake --build build --target check-warpforth`
- [x] Verified pipeline PTX for tiled matmul emits `ld.shared.u64`/`st.shared.u64` for shared buffers
