### PR TITLE
fix(translate): validate control flow stack before popping

### DIFF
--- a/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
@@ -1031,6 +1031,11 @@ LogicalResult ForthParser::parseBody(Value &stack) {
     }
   }
 
+  if (!cfStack.empty()) {
+    cfStack.clear();
+    return emitError("unclosed control flow (missing THEN, REPEAT, or UNTIL?)");
+  }
+
   return success();
 }
 

--- a/test/Translation/Forth/begin-begin-repeat-mismatch-error.forth
+++ b/test/Translation/Forth/begin-begin-repeat-mismatch-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: REPEAT without matching WHILE
+\! kernel main
+BEGIN BEGIN REPEAT

--- a/test/Translation/Forth/begin-then-mismatch-error.forth
+++ b/test/Translation/Forth/begin-then-mismatch-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: THEN without matching IF
+\! kernel main
+BEGIN THEN

--- a/test/Translation/Forth/else-without-if-error.forth
+++ b/test/Translation/Forth/else-without-if-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: ELSE without matching IF
+\! kernel main
+ELSE

--- a/test/Translation/Forth/if-repeat-mismatch-error.forth
+++ b/test/Translation/Forth/if-repeat-mismatch-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: REPEAT without matching WHILE
+\! kernel main
+1 IF REPEAT

--- a/test/Translation/Forth/if-until-mismatch-error.forth
+++ b/test/Translation/Forth/if-until-mismatch-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: UNTIL without matching BEGIN
+\! kernel main
+IF UNTIL

--- a/test/Translation/Forth/repeat-without-while-error.forth
+++ b/test/Translation/Forth/repeat-without-while-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: REPEAT without matching WHILE
+\! kernel main
+REPEAT

--- a/test/Translation/Forth/then-without-if-error.forth
+++ b/test/Translation/Forth/then-without-if-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: THEN without matching IF
+\! kernel main
+THEN

--- a/test/Translation/Forth/unclosed-begin-while-error.forth
+++ b/test/Translation/Forth/unclosed-begin-while-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: unclosed control flow (missing THEN, REPEAT, or UNTIL?)
+\! kernel main
+BEGIN 1 WHILE 42

--- a/test/Translation/Forth/unclosed-if-error.forth
+++ b/test/Translation/Forth/unclosed-if-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: unclosed control flow (missing THEN, REPEAT, or UNTIL?)
+\! kernel main
+1 IF 42

--- a/test/Translation/Forth/until-without-begin-error.forth
+++ b/test/Translation/Forth/until-without-begin-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: UNTIL without matching BEGIN
+\! kernel main
+UNTIL

--- a/test/Translation/Forth/while-without-begin-error.forth
+++ b/test/Translation/Forth/while-without-begin-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: WHILE without matching BEGIN
+\! kernel main
+WHILE


### PR DESCRIPTION
## Summary
- Add empty-stack guards and tag validation before each `cfStack.pop_back_val()` in the Forth translator
- Mismatched control flow words (e.g. `THEN` without `IF`, `REPEAT` without `WHILE`) now produce clear error messages instead of crashing

## Test plan
- [x] Added 7 negative test cases covering empty-stack and tag-mismatch scenarios
- [x] All 91 tests pass

Closes #21