### PR TITLE
docs: rename CLAUDE.md to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# AGENTS.md
 
 WarpForth is an MLIR-based compiler for the Forth programming language targeting GPU kernels. It implements a custom MLIR dialect for Forth stack operations and converts them to executable PTX.
 
@@ -107,3 +107,4 @@ uv run ruff format gpu_test/
 ## Agent Instructions
 
 - Use context7 MCP for MLIR API documentation: query with `/websites/mlir_llvm` for MLIR dialects, operations, types, and conversion patterns
+- Do not add attribution, including AI attribution, co-author trailers, or thread IDs, to commit messages


### PR DESCRIPTION
## Summary
- rename `CLAUDE.md` to `AGENTS.md`
- update the document heading to match
- prohibit attribution, co-author trailers, and thread IDs in commit messages

## Verification
- confirmed no remaining references to `CLAUDE.md`
- documentation-only change; no tests required