### PR TITLE
ci: add clang-tidy checks to CI

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -4,7 +4,13 @@ set -euo pipefail
 llvm_root=/usr/lib/llvm-20
 
 command -v cmake >/dev/null
+command -v clang-20 >/dev/null
+command -v clang++-20 >/dev/null
+command -v clang-tidy-20 >/dev/null
+command -v run-clang-tidy-20.py >/dev/null
 command -v uv >/dev/null
 test -f "$llvm_root/lib/cmake/mlir/MLIRConfig.cmake"
+test -f build/compile_commands.json
+grep -Eq '^CMAKE_CXX_COMPILER:.*=.*clang\+\+-20$' build/CMakeCache.txt
 
 echo "WarpForth orb environment is ready."

--- a/.agents/setup
+++ b/.agents/setup
@@ -19,7 +19,9 @@ install_system_dependencies() {
   local packages=(
     build-essential
     ca-certificates
+    clang-20
     clang-format-20
+    clang-tidy-20
     cmake
     curl
     gnupg
@@ -80,6 +82,8 @@ configure_login_shell() {
 
 $marker
 if [[ "\${PWD}" == "$repo_root" ]]; then
+  export CC=clang-20
+  export CXX=clang++-20
   export LLVM_DIR="$llvm_root/lib/cmake/llvm"
   export MLIR_DIR="$llvm_root/lib/cmake/mlir"
   export PATH="$llvm_root/bin:\${PATH}"
@@ -99,6 +103,8 @@ configure_build() {
     -ULINKER_SUPPORTS_COLOR_DIAGNOSTICS \
     -ULLVM_USE_LINKER \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang-20 \
+    -DCMAKE_CXX_COMPILER=clang++-20 \
     -DMLIR_DIR="$llvm_root/lib/cmake/mlir" \
     -DLLVM_DIR="$llvm_root/lib/cmake/llvm"
 }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,73 @@
+Checks: >
+  -*,
+  clang-diagnostic-*,
+  llvm-*,
+  misc-*,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
+  readability-identifier-naming,
+  bugprone-argument-comment,
+  bugprone-assert-side-effect,
+  bugprone-branch-clone,
+  bugprone-copy-constructor-init,
+  bugprone-dangling-handle,
+  bugprone-dynamic-static-initializers,
+  bugprone-macro-parentheses,
+  bugprone-macro-repeated-side-effects,
+  bugprone-misplaced-widening-cast,
+  bugprone-move-forwarding-reference,
+  bugprone-multiple-statement-macro,
+  bugprone-suspicious-semicolon,
+  bugprone-swapped-arguments,
+  bugprone-terminating-continue,
+  bugprone-unused-raii,
+  bugprone-unused-return-value,
+  modernize-loop-convert,
+  modernize-make-unique,
+  modernize-raw-string-literal,
+  modernize-use-bool-literals,
+  modernize-use-default-member-init,
+  modernize-use-emplace,
+  modernize-use-equals-default,
+  modernize-use-nullptr,
+  modernize-use-override,
+  modernize-use-using,
+  performance-for-range-copy,
+  performance-implicit-conversion-in-loop,
+  performance-inefficient-algorithm,
+  performance-inefficient-vector-operation,
+  performance-move-const-arg,
+  performance-no-automatic-move,
+  performance-trivially-destructible,
+  performance-unnecessary-copy-initialization,
+  performance-unnecessary-value-param,
+  readability-avoid-const-params-in-decls,
+  readability-const-return-type,
+  readability-container-size-empty,
+  readability-inconsistent-declaration-parameter-name,
+  readability-misleading-indentation,
+  readability-redundant-control-flow,
+  readability-redundant-smartptr-get,
+  readability-simplify-boolean-expr,
+  readability-simplify-subscript-expr,
+  readability-use-anyofallof
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*/include/.*'
+ExcludeHeaderFilterRegex: '.*/build[^/]*/.*'
+CheckOptions:
+  readability-identifier-naming.ClassCase: CamelCase
+  readability-identifier-naming.EnumCase: CamelCase
+  readability-identifier-naming.FunctionCase: camelBack
+  readability-identifier-naming.FunctionIgnoredRegexp: LLVMFuzzerTestOneInput
+  readability-identifier-naming.IgnoreMainLikeFunctions: true
+  readability-identifier-naming.MemberCase: camelBack
+  readability-identifier-naming.ParameterCase: camelBack
+  readability-identifier-naming.UnionCase: CamelCase
+  readability-identifier-naming.VariableCase: camelBack
+  readability-redundant-member-init.IgnoreBaseInCopyConstructors: true
+  modernize-use-default-member-init.UseAssignment: true
+  modernize-use-using.IgnoreExternC: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           sudo add-apt-repository -y "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_VERSION} main"
           sudo apt-get update
           sudo apt-get install -y \
+            clang-${LLVM_VERSION} \
+            clang-format-${LLVM_VERSION} \
+            clang-tidy-${LLVM_VERSION} \
             llvm-${LLVM_VERSION}-dev \
             libmlir-${LLVM_VERSION}-dev \
             mlir-${LLVM_VERSION}-tools
@@ -35,13 +38,19 @@ jobs:
         run: |
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DMLIR_DIR=/usr/lib/llvm-${LLVM_VERSION}/lib/cmake/mlir
+            -DCMAKE_C_COMPILER=clang-${LLVM_VERSION} \
+            -DCMAKE_CXX_COMPILER=clang++-${LLVM_VERSION} \
+            -DMLIR_DIR=/usr/lib/llvm-${LLVM_VERSION}/lib/cmake/mlir \
+            -DLLVM_DIR=/usr/lib/llvm-${LLVM_VERSION}/lib/cmake/llvm
 
       - name: Build
         run: cmake --build build
 
       - name: Test
         run: cmake --build build --target check-warpforth
+
+      - name: Check C++ with clang-tidy
+        run: cmake --build build --target check-clang-tidy
 
       - name: Check C++ formatting
         run: cmake --build build --target check-format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,13 @@ cmake --build build --target format
 
 # Run tests (requires: uv sync)
 cmake --build build --target check-warpforth
+
+# Run clang-tidy
+cmake --build build --target check-clang-tidy
 ```
 
-Requires MLIR/LLVM with `MLIR_DIR` and `LLVM_DIR` configured in CMake.
+Requires Clang 20 and MLIR/LLVM with `MLIR_DIR` and `LLVM_DIR` configured in
+CMake.
 
 ## Key Files
 
@@ -103,6 +107,9 @@ uv run ruff format gpu_test/
 - Document stack effects as `( input -- output )`
 - C++17 required
 - Use `clang-format` (config in `.clang-format`)
+- Run `check-clang-tidy` after C++ changes; do not apply fixes automatically
+- Add `NOLINT` suppressions only for documented false positives or deliberate
+  project exceptions
 
 ## Agent Instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,6 @@ uv run ruff format gpu_test/
 - C++17 required
 - Use `clang-format` (config in `.clang-format`)
 - Run `check-clang-tidy` after C++ changes; do not apply fixes automatically
-- Add `NOLINT` suppressions only for documented false positives or deliberate
-  project exceptions
 
 ## Agent Instructions
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(warpforth LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package(MLIR REQUIRED CONFIG)
 
@@ -32,6 +33,30 @@ add_definitions(${LLVM_DEFINITIONS})
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(tools)
+
+# Add clang-tidy target after the TableGen targets it depends on are defined.
+find_program(CLANG_TIDY_EXECUTABLE
+  NAMES clang-tidy-${LLVM_VERSION_MAJOR} clang-tidy
+  HINTS ${LLVM_TOOLS_BINARY_DIR}
+  REQUIRED)
+find_program(RUN_CLANG_TIDY_EXECUTABLE
+  NAMES run-clang-tidy-${LLVM_VERSION_MAJOR}.py run-clang-tidy
+  HINTS ${LLVM_TOOLS_BINARY_DIR}
+  REQUIRED)
+add_custom_target(check-clang-tidy
+  COMMAND ${RUN_CLANG_TIDY_EXECUTABLE}
+    -clang-tidy-binary ${CLANG_TIDY_EXECUTABLE}
+    -config-file ${PROJECT_SOURCE_DIR}/.clang-tidy
+    -exclude-header-filter ^${PROJECT_BINARY_DIR}/
+    -p ${PROJECT_BINARY_DIR}
+    -j 2
+    -quiet
+  DEPENDS
+    MLIRConversionPassIncGen
+    MLIRForthOpsIncGen
+  COMMENT "Running clang-tidy"
+  VERBATIM
+)
 
 # Test infrastructure (lit + FileCheck)
 find_program(LIT_COMMAND NAMES lit llvm-lit

--- a/include/warpforth/Conversion/ForthToGPU/ForthToGPU.h
+++ b/include/warpforth/Conversion/ForthToGPU/ForthToGPU.h
@@ -1,11 +1,11 @@
-#ifndef WARPFORTH_CONVERSION_FORTHTOGPU_FORTHTOGPU_H
-#define WARPFORTH_CONVERSION_FORTHTOGPU_FORTHTOGPU_H
-
 //===- ForthToGPU.h - Forth to GPU conversion pass -------------*- C++ -*-===//
 //
 // This file declares the pass for converting Forth dialect to GPU dialect.
 //
 //===----------------------------------------------------------------------===//
+
+#ifndef WARPFORTH_CONVERSION_FORTHTOGPU_FORTHTOGPU_H
+#define WARPFORTH_CONVERSION_FORTHTOGPU_FORTHTOGPU_H
 
 #include "mlir/Pass/Pass.h"
 #include <memory>

--- a/include/warpforth/Conversion/ForthToGPU/ForthToGPU.h
+++ b/include/warpforth/Conversion/ForthToGPU/ForthToGPU.h
@@ -1,10 +1,11 @@
+#ifndef WARPFORTH_CONVERSION_FORTHTOGPU_FORTHTOGPU_H
+#define WARPFORTH_CONVERSION_FORTHTOGPU_FORTHTOGPU_H
+
 //===- ForthToGPU.h - Forth to GPU conversion pass -------------*- C++ -*-===//
 //
 // This file declares the pass for converting Forth dialect to GPU dialect.
 //
 //===----------------------------------------------------------------------===//
-
-#pragma once
 
 #include "mlir/Pass/Pass.h"
 #include <memory>
@@ -22,3 +23,5 @@ std::unique_ptr<Pass> createConvertForthToGPUPass();
 
 } // namespace warpforth
 } // namespace mlir
+
+#endif

--- a/include/warpforth/Conversion/ForthToMemRef/ForthToMemRef.h
+++ b/include/warpforth/Conversion/ForthToMemRef/ForthToMemRef.h
@@ -1,11 +1,12 @@
+#ifndef WARPFORTH_CONVERSION_FORTHTOMEMREF_FORTHTOMEMREF_H
+#define WARPFORTH_CONVERSION_FORTHTOMEMREF_FORTHTOMEMREF_H
+
 //===- ForthToMemRef.h - Forth to MemRef conversion ------------*- C++ -*-===//
 //
 // This file declares the pass for converting Forth dialect operations to
 // MemRef dialect operations.
 //
 //===----------------------------------------------------------------------===//
-
-#pragma once
 
 #include "mlir/Pass/Pass.h"
 #include <memory>
@@ -21,3 +22,5 @@ std::unique_ptr<Pass> createConvertForthToMemRefPass();
 
 } // namespace warpforth
 } // namespace mlir
+
+#endif

--- a/include/warpforth/Conversion/ForthToMemRef/ForthToMemRef.h
+++ b/include/warpforth/Conversion/ForthToMemRef/ForthToMemRef.h
@@ -1,12 +1,12 @@
-#ifndef WARPFORTH_CONVERSION_FORTHTOMEMREF_FORTHTOMEMREF_H
-#define WARPFORTH_CONVERSION_FORTHTOMEMREF_FORTHTOMEMREF_H
-
 //===- ForthToMemRef.h - Forth to MemRef conversion ------------*- C++ -*-===//
 //
 // This file declares the pass for converting Forth dialect operations to
 // MemRef dialect operations.
 //
 //===----------------------------------------------------------------------===//
+
+#ifndef WARPFORTH_CONVERSION_FORTHTOMEMREF_FORTHTOMEMREF_H
+#define WARPFORTH_CONVERSION_FORTHTOMEMREF_FORTHTOMEMREF_H
 
 #include "mlir/Pass/Pass.h"
 #include <memory>

--- a/include/warpforth/Conversion/Passes.h
+++ b/include/warpforth/Conversion/Passes.h
@@ -1,10 +1,11 @@
+#ifndef WARPFORTH_CONVERSION_PASSES_H
+#define WARPFORTH_CONVERSION_PASSES_H
+
 //===- Passes.h - Conversion Pass Registration -----------------*- C++ -*-===//
 //
 // This file declares the registration functions for conversion passes.
 //
 //===----------------------------------------------------------------------===//
-
-#pragma once
 
 #include "mlir/Pass/Pass.h"
 #include <memory>
@@ -22,3 +23,5 @@ void buildWarpForthPipeline(OpPassManager &pm);
 
 } // namespace warpforth
 } // namespace mlir
+
+#endif

--- a/include/warpforth/Conversion/Passes.h
+++ b/include/warpforth/Conversion/Passes.h
@@ -1,11 +1,11 @@
-#ifndef WARPFORTH_CONVERSION_PASSES_H
-#define WARPFORTH_CONVERSION_PASSES_H
-
 //===- Passes.h - Conversion Pass Registration -----------------*- C++ -*-===//
 //
 // This file declares the registration functions for conversion passes.
 //
 //===----------------------------------------------------------------------===//
+
+#ifndef WARPFORTH_CONVERSION_PASSES_H
+#define WARPFORTH_CONVERSION_PASSES_H
 
 #include "mlir/Pass/Pass.h"
 #include <memory>

--- a/include/warpforth/Dialect/Forth/ForthDialect.h
+++ b/include/warpforth/Dialect/Forth/ForthDialect.h
@@ -1,10 +1,11 @@
+#ifndef WARPFORTH_DIALECT_FORTH_FORTHDIALECT_H
+#define WARPFORTH_DIALECT_FORTH_FORTHDIALECT_H
+
 //===- ForthDialect.h - Forth dialect ---------------------------*- C++ -*-===//
 //
 // This file defines the Forth dialect.
 //
 //===----------------------------------------------------------------------===//
-
-#pragma once
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/Dialect.h"
@@ -19,3 +20,5 @@
 
 #define GET_OP_CLASSES
 #include "warpforth/Dialect/Forth/ForthOps.h.inc"
+
+#endif

--- a/include/warpforth/Dialect/Forth/ForthDialect.h
+++ b/include/warpforth/Dialect/Forth/ForthDialect.h
@@ -1,11 +1,11 @@
-#ifndef WARPFORTH_DIALECT_FORTH_FORTHDIALECT_H
-#define WARPFORTH_DIALECT_FORTH_FORTHDIALECT_H
-
 //===- ForthDialect.h - Forth dialect ---------------------------*- C++ -*-===//
 //
 // This file defines the Forth dialect.
 //
 //===----------------------------------------------------------------------===//
+
+#ifndef WARPFORTH_DIALECT_FORTH_FORTHDIALECT_H
+#define WARPFORTH_DIALECT_FORTH_FORTHDIALECT_H
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/Dialect.h"

--- a/include/warpforth/Translation/ForthToMLIR/ForthToMLIR.h
+++ b/include/warpforth/Translation/ForthToMLIR/ForthToMLIR.h
@@ -1,10 +1,11 @@
+#ifndef WARPFORTH_TRANSLATION_FORTHTOMLIR_FORTHTOMLIR_H
+#define WARPFORTH_TRANSLATION_FORTHTOMLIR_FORTHTOMLIR_H
+
 //===- ForthToMLIR.h - Forth to MLIR translation ----------------*- C++ -*-===//
 //
 // This file declares the registration function for Forth-to-MLIR translation.
 //
 //===----------------------------------------------------------------------===//
-
-#pragma once
 
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OwningOpRef.h"
@@ -26,3 +27,5 @@ OwningOpRef<ModuleOp> parseForthSource(llvm::SourceMgr &sourceMgr,
 
 } // namespace forth
 } // namespace mlir
+
+#endif

--- a/include/warpforth/Translation/ForthToMLIR/ForthToMLIR.h
+++ b/include/warpforth/Translation/ForthToMLIR/ForthToMLIR.h
@@ -1,11 +1,11 @@
-#ifndef WARPFORTH_TRANSLATION_FORTHTOMLIR_FORTHTOMLIR_H
-#define WARPFORTH_TRANSLATION_FORTHTOMLIR_FORTHTOMLIR_H
-
 //===- ForthToMLIR.h - Forth to MLIR translation ----------------*- C++ -*-===//
 //
 // This file declares the registration function for Forth-to-MLIR translation.
 //
 //===----------------------------------------------------------------------===//
+
+#ifndef WARPFORTH_TRANSLATION_FORTHTOMLIR_FORTHTOMLIR_H
+#define WARPFORTH_TRANSLATION_FORTHTOMLIR_FORTHTOMLIR_H
 
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OwningOpRef.h"

--- a/include/warpforth/Translation/MLIRToPTX/MLIRToPTX.h
+++ b/include/warpforth/Translation/MLIRToPTX/MLIRToPTX.h
@@ -1,11 +1,12 @@
+#ifndef WARPFORTH_TRANSLATION_MLIRTOPTX_MLIRTOPTX_H
+#define WARPFORTH_TRANSLATION_MLIRTOPTX_MLIRTOPTX_H
+
 //===- MLIRToPTX.h - MLIR to PTX translation --------------------*- C++ -*-===//
 //
 // This file declares the registration function for MLIR-to-PTX translation.
 // Extracts PTX assembly from gpu.binary operations.
 //
 //===----------------------------------------------------------------------===//
-
-#pragma once
 
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Support/LogicalResult.h"
@@ -24,3 +25,5 @@ LogicalResult extractPTXFromModule(ModuleOp module, llvm::raw_ostream &output);
 
 } // namespace warpforth
 } // namespace mlir
+
+#endif

--- a/include/warpforth/Translation/MLIRToPTX/MLIRToPTX.h
+++ b/include/warpforth/Translation/MLIRToPTX/MLIRToPTX.h
@@ -1,12 +1,12 @@
-#ifndef WARPFORTH_TRANSLATION_MLIRTOPTX_MLIRTOPTX_H
-#define WARPFORTH_TRANSLATION_MLIRTOPTX_MLIRTOPTX_H
-
 //===- MLIRToPTX.h - MLIR to PTX translation --------------------*- C++ -*-===//
 //
 // This file declares the registration function for MLIR-to-PTX translation.
 // Extracts PTX assembly from gpu.binary operations.
 //
 //===----------------------------------------------------------------------===//
+
+#ifndef WARPFORTH_TRANSLATION_MLIRTOPTX_MLIRTOPTX_H
+#define WARPFORTH_TRANSLATION_MLIRTOPTX_MLIRTOPTX_H
 
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Support/LogicalResult.h"

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
@@ -64,7 +64,7 @@ static std::string toUpperCase(llvm::StringRef str) {
 
 ForthLexer::ForthLexer(llvm::SourceMgr &sourceMgr, unsigned bufferID)
     : sourceMgr(sourceMgr), bufferID(bufferID) {
-  auto buffer = sourceMgr.getMemoryBuffer(bufferID);
+  const auto *buffer = sourceMgr.getMemoryBuffer(bufferID);
   curPtr = buffer->getBufferStart();
   endPtr = buffer->getBufferEnd();
 }
@@ -103,13 +103,13 @@ bool ForthLexer::isWhitespace(char c) const {
 }
 
 void ForthLexer::reset() {
-  auto buffer = sourceMgr.getMemoryBuffer(bufferID);
+  const auto *buffer = sourceMgr.getMemoryBuffer(bufferID);
   curPtr = buffer->getBufferStart();
   endPtr = buffer->getBufferEnd();
 }
 
 void ForthLexer::resetTo(const char *ptr) {
-  auto buffer = sourceMgr.getMemoryBuffer(bufferID);
+  const auto *buffer = sourceMgr.getMemoryBuffer(bufferID);
   curPtr = ptr;
   endPtr = buffer->getBufferEnd();
 }
@@ -226,7 +226,7 @@ LogicalResult ForthParser::emitErrorAt(llvm::SMLoc loc,
 }
 
 LogicalResult ForthParser::parseHeader() {
-  auto buffer = sourceMgr.getMemoryBuffer(sourceMgr.getMainFileID());
+  const auto *buffer = sourceMgr.getMemoryBuffer(sourceMgr.getMainFileID());
   const char *bufStart = buffer->getBufferStart();
   const char *bufEnd = buffer->getBufferEnd();
 
@@ -483,9 +483,11 @@ Value ForthParser::emitOperation(StringRef word, Value inputStack,
   }
 
   // Built-in operations
+  // Keep these in one dispatch chain so the alternatives remain visually
+  // grouped despite each branch returning.
   if (word == "DUP") {
     return builder.create<forth::DupOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "DROP") {
+  } else if (word == "DROP") { // NOLINT(llvm-else-after-return)
     return builder.create<forth::DropOp>(loc, stackType, inputStack)
         .getResult();
   } else if (word == "SWAP") {

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
@@ -483,265 +483,355 @@ Value ForthParser::emitOperation(StringRef word, Value inputStack,
   }
 
   // Built-in operations
-  // Keep these in one dispatch chain so the alternatives remain visually
-  // grouped despite each branch returning.
   if (word == "DUP") {
     return builder.create<forth::DupOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "DROP") { // NOLINT(llvm-else-after-return)
+  }
+  if (word == "DROP") {
     return builder.create<forth::DropOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SWAP") {
+  }
+  if (word == "SWAP") {
     return builder.create<forth::SwapOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "OVER") {
+  }
+  if (word == "OVER") {
     return builder.create<forth::OverOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "ROT") {
+  }
+  if (word == "ROT") {
     return builder.create<forth::RotOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "NIP") {
+  }
+  if (word == "NIP") {
     return builder.create<forth::NipOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "TUCK") {
+  }
+  if (word == "TUCK") {
     return builder.create<forth::TuckOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "PICK") {
+  }
+  if (word == "PICK") {
     return builder.create<forth::PickOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "ROLL") {
+  }
+  if (word == "ROLL") {
     return builder.create<forth::RollOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "+" || word == "ADD") {
+  }
+  if (word == "+" || word == "ADD") {
     return builder.create<forth::AddIOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "-" || word == "SUB") {
+  }
+  if (word == "-" || word == "SUB") {
     return builder.create<forth::SubIOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "*" || word == "MUL") {
+  }
+  if (word == "*" || word == "MUL") {
     return builder.create<forth::MulIOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "/" || word == "DIV") {
+  }
+  if (word == "/" || word == "DIV") {
     return builder.create<forth::DivIOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "F+") {
+  }
+  if (word == "F+") {
     return builder.create<forth::AddFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "F-") {
+  }
+  if (word == "F-") {
     return builder.create<forth::SubFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "F*") {
+  }
+  if (word == "F*") {
     return builder.create<forth::MulFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "F/") {
+  }
+  if (word == "F/") {
     return builder.create<forth::DivFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "FEXP") {
+  }
+  if (word == "FEXP") {
     return builder.create<forth::ExpFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "FSQRT") {
+  }
+  if (word == "FSQRT") {
     return builder.create<forth::SqrtFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "FLOG") {
+  }
+  if (word == "FLOG") {
     return builder.create<forth::LogFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "FABS") {
+  }
+  if (word == "FABS") {
     return builder.create<forth::AbsFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "FNEG") {
+  }
+  if (word == "FNEG") {
     return builder.create<forth::NegFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "FMAX") {
+  }
+  if (word == "FMAX") {
     return builder.create<forth::MaxFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "FMIN") {
+  }
+  if (word == "FMIN") {
     return builder.create<forth::MinFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "MOD") {
+  }
+  if (word == "MOD") {
     return builder.create<forth::ModOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "AND") {
+  }
+  if (word == "AND") {
     return builder.create<forth::AndOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "OR") {
+  }
+  if (word == "OR") {
     return builder.create<forth::OrOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "XOR") {
+  }
+  if (word == "XOR") {
     return builder.create<forth::XorOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "NOT") {
+  }
+  if (word == "NOT") {
     return builder.create<forth::NotOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "LSHIFT") {
+  }
+  if (word == "LSHIFT") {
     return builder.create<forth::LshiftOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "RSHIFT") {
+  }
+  if (word == "RSHIFT") {
     return builder.create<forth::RshiftOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "@") {
+  }
+  if (word == "@") {
     return builder.create<forth::LoadIOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "!") {
+  }
+  if (word == "!") {
     return builder.create<forth::StoreIOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "F@") {
+  }
+  if (word == "F@") {
     return builder.create<forth::LoadFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "F!") {
+  }
+  if (word == "F!") {
     return builder.create<forth::StoreFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "S@") {
+  }
+  if (word == "S@") {
     return builder.create<forth::SharedLoadIOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "S!") {
+  }
+  if (word == "S!") {
     return builder.create<forth::SharedStoreIOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SF@") {
+  }
+  if (word == "SF@") {
     return builder.create<forth::SharedLoadFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SF!") {
+  }
+  if (word == "SF!") {
     return builder.create<forth::SharedStoreFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "I8@") {
+  }
+  if (word == "I8@") {
     return builder.create<forth::LoadI8Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "I8!") {
+  }
+  if (word == "I8!") {
     return builder.create<forth::StoreI8Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SI8@") {
+  }
+  if (word == "SI8@") {
     return builder.create<forth::SharedLoadI8Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SI8!") {
+  }
+  if (word == "SI8!") {
     return builder.create<forth::SharedStoreI8Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "I16@") {
+  }
+  if (word == "I16@") {
     return builder.create<forth::LoadI16Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "I16!") {
+  }
+  if (word == "I16!") {
     return builder.create<forth::StoreI16Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SI16@") {
+  }
+  if (word == "SI16@") {
     return builder.create<forth::SharedLoadI16Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SI16!") {
+  }
+  if (word == "SI16!") {
     return builder.create<forth::SharedStoreI16Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "I32@") {
+  }
+  if (word == "I32@") {
     return builder.create<forth::LoadI32Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "I32!") {
+  }
+  if (word == "I32!") {
     return builder.create<forth::StoreI32Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SI32@") {
+  }
+  if (word == "SI32@") {
     return builder.create<forth::SharedLoadI32Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SI32!") {
+  }
+  if (word == "SI32!") {
     return builder.create<forth::SharedStoreI32Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "HF@") {
+  }
+  if (word == "HF@") {
     return builder.create<forth::LoadF16Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "HF!") {
+  }
+  if (word == "HF!") {
     return builder.create<forth::StoreF16Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SHF@") {
+  }
+  if (word == "SHF@") {
     return builder.create<forth::SharedLoadF16Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SHF!") {
+  }
+  if (word == "SHF!") {
     return builder.create<forth::SharedStoreF16Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "BF@") {
+  }
+  if (word == "BF@") {
     return builder.create<forth::LoadBF16Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "BF!") {
+  }
+  if (word == "BF!") {
     return builder.create<forth::StoreBF16Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SBF@") {
+  }
+  if (word == "SBF@") {
     return builder.create<forth::SharedLoadBF16Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SBF!") {
+  }
+  if (word == "SBF!") {
     return builder.create<forth::SharedStoreBF16Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "F32@") {
+  }
+  if (word == "F32@") {
     return builder.create<forth::LoadF32Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "F32!") {
+  }
+  if (word == "F32!") {
     return builder.create<forth::StoreF32Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SF32@") {
+  }
+  if (word == "SF32@") {
     return builder.create<forth::SharedLoadF32Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "SF32!") {
+  }
+  if (word == "SF32!") {
     return builder.create<forth::SharedStoreF32Op>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "TID-X") {
+  }
+  if (word == "TID-X") {
     return builder.create<forth::ThreadIdXOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "TID-Y") {
+  }
+  if (word == "TID-Y") {
     return builder.create<forth::ThreadIdYOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "TID-Z") {
+  }
+  if (word == "TID-Z") {
     return builder.create<forth::ThreadIdZOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "BID-X") {
+  }
+  if (word == "BID-X") {
     return builder.create<forth::BlockIdXOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "BID-Y") {
+  }
+  if (word == "BID-Y") {
     return builder.create<forth::BlockIdYOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "BID-Z") {
+  }
+  if (word == "BID-Z") {
     return builder.create<forth::BlockIdZOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "BDIM-X") {
+  }
+  if (word == "BDIM-X") {
     return builder.create<forth::BlockDimXOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "BDIM-Y") {
+  }
+  if (word == "BDIM-Y") {
     return builder.create<forth::BlockDimYOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "BDIM-Z") {
+  }
+  if (word == "BDIM-Z") {
     return builder.create<forth::BlockDimZOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "GDIM-X") {
+  }
+  if (word == "GDIM-X") {
     return builder.create<forth::GridDimXOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "GDIM-Y") {
+  }
+  if (word == "GDIM-Y") {
     return builder.create<forth::GridDimYOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "GDIM-Z") {
+  }
+  if (word == "GDIM-Z") {
     return builder.create<forth::GridDimZOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "GLOBAL-ID") {
+  }
+  if (word == "GLOBAL-ID") {
     return builder.create<forth::GlobalIdOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "BARRIER") {
+  }
+  if (word == "BARRIER") {
     builder.create<forth::BarrierOp>(loc);
     return inputStack;
-  } else if (word == "=") {
+  }
+  if (word == "=") {
     return builder.create<forth::EqIOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "<") {
+  }
+  if (word == "<") {
     return builder.create<forth::LtIOp>(loc, stackType, inputStack).getResult();
-  } else if (word == ">") {
+  }
+  if (word == ">") {
     return builder.create<forth::GtIOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "<>") {
+  }
+  if (word == "<>") {
     return builder.create<forth::NeIOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "<=") {
+  }
+  if (word == "<=") {
     return builder.create<forth::LeIOp>(loc, stackType, inputStack).getResult();
-  } else if (word == ">=") {
+  }
+  if (word == ">=") {
     return builder.create<forth::GeIOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "F=") {
+  }
+  if (word == "F=") {
     return builder.create<forth::EqFOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "F<") {
+  }
+  if (word == "F<") {
     return builder.create<forth::LtFOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "F>") {
+  }
+  if (word == "F>") {
     return builder.create<forth::GtFOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "F<>") {
+  }
+  if (word == "F<>") {
     return builder.create<forth::NeFOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "F<=") {
+  }
+  if (word == "F<=") {
     return builder.create<forth::LeFOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "F>=") {
+  }
+  if (word == "F>=") {
     return builder.create<forth::GeFOp>(loc, stackType, inputStack).getResult();
-  } else if (word == "S>F") {
+  }
+  if (word == "S>F") {
     return builder.create<forth::IToFOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "F>S") {
+  }
+  if (word == "F>S") {
     return builder.create<forth::FToIOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "0=") {
+  }
+  if (word == "0=") {
     return builder.create<forth::ZeroEqOp>(loc, stackType, inputStack)
         .getResult();
-  } else if (word == "I" || word == "J" || word == "K") {
+  }
+  if (word == "I" || word == "J" || word == "K") {
     int64_t depth = (word == "I") ? 0 : (word == "J") ? 1 : 2;
     if (static_cast<int64_t>(loopStack.size()) < depth + 1) {
       (void)emitError("'" + word.str() + "' requires " +

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.h
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.h
@@ -9,8 +9,8 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
-#include "llvm/Support/SourceMgr.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/Support/SourceMgr.h"
 #include <string>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
## Summary

- add an LLVM/MLIR-aligned clang-tidy configuration and CMake check target
- fix the existing clang-tidy findings in project sources and public headers
- standardize CI and new orb builds on Clang 20 and document the lint workflow

## Validation

- `cmake --build /tmp/warpforth-tidy-build`
- `cmake --build /tmp/warpforth-tidy-build --target check-clang-tidy`
- `cmake --build /tmp/warpforth-tidy-build --target check-warpforth` (109/109 passed)
- `cmake --build /tmp/warpforth-tidy-build --target check-format`
- `bash -n .agents/setup .agents/resume`