### PR TITLE
fix(parser): diagnose unclosed DO loops

### DIFF
--- a/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
@@ -1236,6 +1236,11 @@ LogicalResult ForthParser::parseBody(Value &stack) {
     return emitError("unclosed control flow (missing THEN, REPEAT, or UNTIL?)");
   }
 
+  if (!loopStack.empty()) {
+    loopStack.clear();
+    return emitError("unclosed DO (expected LOOP or +LOOP)");
+  }
+
   return success();
 }
 

--- a/test/Translation/Forth/unclosed-do-error.forth
+++ b/test/Translation/Forth/unclosed-do-error.forth
@@ -1,0 +1,4 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: unclosed DO (expected LOOP or +LOOP)
+\! kernel main
+10 0 DO I

--- a/test/Translation/Forth/unclosed-do-word-boundary-error.forth
+++ b/test/Translation/Forth/unclosed-do-word-boundary-error.forth
@@ -1,0 +1,6 @@
+\ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
+\ CHECK: unclosed DO (expected LOOP or +LOOP)
+\ CHECK-NOT: reference to block defined in another region
+\! kernel main
+: FIRST 10 0 DO I ;
+: SECOND LOOP ;


### PR DESCRIPTION
## Summary
- reject unmatched `DO` contexts when a top-level or word body ends
- clear stale loop parser state before returning the source diagnostic
- cover top-level and cross-word leakage regressions with negative lit tests

## Testing
- `cmake --build build --target format`
- `.venv/bin/lit -v build/test --filter 'unclosed-do'`
- `cmake --build build --target check-warpforth`
- `cmake --build build --target check-clang-tidy`
