### PR TITLE
refactor(conversion): use function signature helper

### DIFF
--- a/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
+++ b/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
@@ -1237,38 +1237,6 @@ struct PushValueOpConversion : public OpConversionPattern<forth::PushValueOp> {
   }
 };
 
-/// Custom FuncOp conversion that calls convertRegionTypes to convert ALL
-/// block args (including non-entry blocks used by CF branch ops).
-/// The built-in pattern only converts the entry block.
-struct FuncOpConversion : public OpConversionPattern<func::FuncOp> {
-  using OpConversionPattern::OpConversionPattern;
-  using OneToNOpAdaptor = OpConversionPattern::OneToNOpAdaptor;
-
-  LogicalResult
-  matchAndRewrite(func::FuncOp funcOp, OneToNOpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto type = funcOp.getFunctionType();
-
-    TypeConverter::SignatureConversion result(type.getNumInputs());
-    SmallVector<Type, 1> newResults;
-    if (failed(getTypeConverter()->convertSignatureArgs(type.getInputs(),
-                                                        result)) ||
-        failed(getTypeConverter()->convertTypes(type.getResults(), newResults)))
-      return failure();
-
-    if (!funcOp.getFunctionBody().empty()) {
-      if (failed(rewriter.convertRegionTypes(&funcOp.getFunctionBody(),
-                                             *getTypeConverter(), &result)))
-        return failure();
-    }
-
-    auto newType = FunctionType::get(rewriter.getContext(),
-                                     result.getConvertedTypes(), newResults);
-    rewriter.modifyOpInPlace(funcOp, [&] { funcOp.setType(newType); });
-    return success();
-  }
-};
-
 /// Conversion pattern for cf::BranchOp with 1:N type conversion.
 /// The built-in populateBranchOpInterfaceTypeConversionPattern uses the old
 /// ArrayRef<Value> signature and crashes on 1:N conversions.
@@ -1443,9 +1411,12 @@ struct ConvertForthToMemRefPass
     // GlobalIdOp has custom pattern
     patterns.add<GlobalIdOpConversion>(typeConverter, context);
 
-    // Custom FuncOp + branch patterns for 1:N type conversion
-    patterns.add<FuncOpConversion, BranchOpConversion, CondBranchOpConversion>(
-        typeConverter, context);
+    populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
+        patterns, typeConverter);
+
+    // Custom branch patterns are required for 1:N type conversion.
+    patterns.add<BranchOpConversion, CondBranchOpConversion>(typeConverter,
+                                                             context);
     populateCallOpTypeConversionPattern(patterns, typeConverter);
     populateReturnOpTypeConversionPattern(patterns, typeConverter);
 

--- a/test/Conversion/ForthToMemRef/control-flow.mlir
+++ b/test/Conversion/ForthToMemRef/control-flow.mlir
@@ -1,6 +1,7 @@
 // RUN: %warpforth-opt --convert-forth-to-memref %s | %FileCheck %s
 
-// Test: IF/ELSE/THEN and IF/THEN conversion to memref with CF-based control flow
+// Test: IF/ELSE/THEN and IF/THEN conversion to memref with CF-based control flow.
+// The non-entry block checks cover function-region signature conversion.
 // Forth: 1 IF 42 ELSE 99 THEN  0 IF 7 THEN
 
 // CHECK-LABEL: func.func private @main


### PR DESCRIPTION
## Summary
- replace the local func.func signature conversion with MLIR's standard FunctionOpInterface helper
- retain the custom 1:N branch and conditional-branch conversions
- document the existing non-entry block regression coverage

## Testing
- cmake --build build --target format
- focused lit tests: control-flow.mlir, nested-control-flow.mlir, user-defined-words.mlir (3/3 passed)
- cmake --build build --target check-warpforth (109/109 passed)
- cmake --build build --target check-clang-tidy