### PR TITLE
refactor(dialect): make parameter references SSA-based

### DIFF
--- a/include/warpforth/Dialect/Forth/ForthOps.td
+++ b/include/warpforth/Dialect/Forth/ForthOps.td
@@ -589,15 +589,18 @@ def Forth_SharedStoreF32Op : Forth_StackOpBase<"shared_store_f32"> {
 }
 
 def Forth_ParamRefOp : Forth_Op<"param_ref", [Pure]> {
-  let summary = "Push kernel parameter address onto stack";
+  let summary = "Push a kernel parameter onto the stack";
   let description = [{
-    Pushes the byte address of a named kernel parameter onto the stack.
-    Forth semantics: ( -- addr )
+    Pushes an array parameter's byte address or a scalar parameter's value onto
+    the stack.
+    Forth semantics: ( -- value )
   }];
-  let arguments = (ins Forth_StackType:$input_stack, StrAttr:$param_name);
+  let arguments = (ins Forth_StackType:$input_stack,
+                       AnyTypeOf<[I64MemRef, F64MemRef, I64, F64]>:$parameter);
   let results = (outs Forth_StackType:$output_stack);
   let assemblyFormat = [{
-    $input_stack $param_name attr-dict `:` type($input_stack) `->` type($output_stack)
+    $input_stack $parameter attr-dict `:` type($input_stack) `,`
+    type($parameter) `->` type($output_stack)
   }];
 }
 

--- a/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
+++ b/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
@@ -715,7 +715,7 @@ struct ZeroEqOpConversion : public OpConversionPattern<forth::ZeroEqOp> {
 };
 
 /// Conversion pattern for forth.param_ref operation.
-/// Pushes the byte address of a named kernel parameter onto the stack.
+/// Pushes an array parameter's byte address or a scalar parameter's value.
 struct ParamRefOpConversion : public OpConversionPattern<forth::ParamRefOp> {
   ParamRefOpConversion(const TypeConverter &typeConverter, MLIRContext *context)
       : OpConversionPattern<forth::ParamRefOp>(typeConverter, context) {}
@@ -728,40 +728,22 @@ struct ParamRefOpConversion : public OpConversionPattern<forth::ParamRefOp> {
     ValueRange inputStack = adaptor.getOperands()[0];
     Value memref = inputStack[0];
     Value stackPtr = inputStack[1];
-
-    // Find the function argument with matching forth.param_name
-    auto funcOp = op->getParentOfType<func::FuncOp>();
-    if (!funcOp)
-      return rewriter.notifyMatchFailure(op, "not inside a func.func");
-
-    StringRef paramName = op.getParamName();
-    Value memrefArg;
-    for (unsigned i = 0; i < funcOp.getNumArguments(); ++i) {
-      auto nameAttr =
-          funcOp.getArgAttrOfType<StringAttr>(i, "forth.param_name");
-      if (nameAttr && nameAttr.getValue() == paramName) {
-        memrefArg = funcOp.getArgument(i);
-        break;
-      }
-    }
-    if (!memrefArg)
-      return rewriter.notifyMatchFailure(
-          op, "no function argument with param_name: " + paramName);
+    Value parameter = adaptor.getOperands()[1].front();
 
     Value valueToPush;
-    if (auto memrefType = dyn_cast<MemRefType>(memrefArg.getType())) {
+    if (isa<MemRefType>(parameter.getType())) {
       // Extract pointer as index, then cast to i64
       Value ptrIndex = rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(
-          loc, memrefArg);
+          loc, parameter);
       valueToPush = rewriter.create<arith::IndexCastOp>(
           loc, rewriter.getI64Type(), ptrIndex);
-    } else if (memrefArg.getType().isInteger(64)) {
+    } else if (parameter.getType().isInteger(64)) {
       // Scalar i64 param: push value directly.
-      valueToPush = memrefArg;
-    } else if (memrefArg.getType().isF64()) {
+      valueToPush = parameter;
+    } else if (parameter.getType().isF64()) {
       // Scalar f64 param: bitcast to i64 for stack storage.
       valueToPush = rewriter.create<arith::BitcastOp>(
-          loc, rewriter.getI64Type(), memrefArg);
+          loc, rewriter.getI64Type(), parameter);
     } else {
       return rewriter.notifyMatchFailure(
           op, "unsupported param argument type for param_ref");

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
@@ -419,15 +419,13 @@ Value ForthParser::emitOperation(StringRef word, Value inputStack,
     }
   }
 
-  // Check if word is a param name (only valid outside word definitions)
+  // Check if word is a param name (only valid outside word definitions).
   if (!inWordDefinition) {
-    for (const auto &param : paramDecls) {
-      if (word == param.name) {
-        return builder
-            .create<forth::ParamRefOp>(loc, stackType, inputStack,
-                                       builder.getStringAttr(param.name))
-            .getResult();
-      }
+    auto it = paramValues.find(word);
+    if (it != paramValues.end()) {
+      return builder
+          .create<forth::ParamRefOp>(loc, stackType, inputStack, it->second)
+          .getOutputStack();
     }
   } else {
     for (const auto &param : paramDecls) {
@@ -1461,6 +1459,12 @@ OwningOpRef<ModuleOp> ForthParser::parseModule() {
   // Create the entry block with arguments
   Block *entryBlock = funcOp.addEntryBlock();
   builder.setInsertionPointToStart(entryBlock);
+
+  // Resolve parameter names to their entry block arguments before parsing the
+  // kernel body. Param references then carry the argument as an SSA operand.
+  for (auto [param, argument] :
+       llvm::zip(paramDecls, entryBlock->getArguments()))
+    paramValues[param.name] = argument;
 
   // Emit shared memory allocations at kernel entry
   for (const auto &shared : sharedDecls) {

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.h
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.h
@@ -100,6 +100,7 @@ private:
   std::unordered_set<std::string> wordDefs;
   std::vector<ParamDecl> paramDecls;
   std::vector<SharedDecl> sharedDecls;
+  llvm::StringMap<Value> paramValues;
   llvm::StringMap<Value> sharedAllocs;
   llvm::StringMap<Value> localVars;
   std::string kernelName;

--- a/test/Conversion/ForthToMemRef/param-ref.mlir
+++ b/test/Conversion/ForthToMemRef/param-ref.mlir
@@ -1,15 +1,37 @@
 // RUN: %warpforth-opt --convert-forth-to-memref %s | %FileCheck %s
 
-// CHECK-LABEL: func.func private @main(%{{.*}}: memref<256xi64> {forth.param_name = "data"})
-// CHECK: memref.alloca() : memref<256xi64>
-// CHECK: memref.extract_aligned_pointer_as_index %{{.*}} : memref<256xi64> -> index
-// CHECK: arith.index_cast %{{.*}} : index to i64
-// CHECK: memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<256xi64>
+// CHECK-LABEL: func.func private @array_param(
+// CHECK-SAME: %[[ARRAY:.*]]: memref<256xi64> {forth.param_name = "data"})
+// CHECK: %[[STACK:.*]] = memref.alloca() : memref<256xi64>
+// CHECK: %[[POINTER:.*]] = memref.extract_aligned_pointer_as_index %[[ARRAY]] : memref<256xi64> -> index
+// CHECK: %[[ADDRESS:.*]] = arith.index_cast %[[POINTER]] : index to i64
+// CHECK: memref.store %[[ADDRESS]], %[[STACK]][%{{.*}}] : memref<256xi64>
+
+// CHECK-LABEL: func.func private @i64_param(
+// CHECK-SAME: %[[INTEGER:.*]]: i64 {forth.param_name = "count"})
+// CHECK: %[[STACK:.*]] = memref.alloca() : memref<256xi64>
+// CHECK: memref.store %[[INTEGER]], %[[STACK]][%{{.*}}] : memref<256xi64>
+
+// CHECK-LABEL: func.func private @f64_param(
+// CHECK-SAME: %[[FLOAT:.*]]: f64 {forth.param_name = "scale"})
+// CHECK: %[[STACK:.*]] = memref.alloca() : memref<256xi64>
+// CHECK: %[[BITS:.*]] = arith.bitcast %[[FLOAT]] : f64 to i64
+// CHECK: memref.store %[[BITS]], %[[STACK]][%{{.*}}] : memref<256xi64>
 
 module {
-  func.func private @main(%arg0: memref<256xi64> {forth.param_name = "data"}) {
+  func.func private @array_param(%arg0: memref<256xi64> {forth.param_name = "data"}) {
     %0 = forth.stack !forth.stack
-    %1 = forth.param_ref %0 "data" : !forth.stack -> !forth.stack
+    %1 = forth.param_ref %0 %arg0 : !forth.stack, memref<256xi64> -> !forth.stack
+    return
+  }
+  func.func private @i64_param(%arg0: i64 {forth.param_name = "count"}) {
+    %0 = forth.stack !forth.stack
+    %1 = forth.param_ref %0 %arg0 : !forth.stack, i64 -> !forth.stack
+    return
+  }
+  func.func private @f64_param(%arg0: f64 {forth.param_name = "scale"}) {
+    %0 = forth.stack !forth.stack
+    %1 = forth.param_ref %0 %arg0 : !forth.stack, f64 -> !forth.stack
     return
   }
 }

--- a/test/Translation/Forth/float-params.forth
+++ b/test/Translation/Forth/float-params.forth
@@ -4,8 +4,8 @@
 \ CHECK: func.func private @main(%arg0: memref<256xf64> {forth.param_name = "DATA"}, %arg1: f64 {forth.param_name = "SCALE"})
 
 \ Check param refs work
-\ CHECK: forth.param_ref %{{.*}} "DATA"
-\ CHECK: forth.param_ref %{{.*}} "SCALE"
+\ CHECK: forth.param_ref %{{.*}} %arg0 : !forth.stack, memref<256xf64> -> !forth.stack
+\ CHECK: forth.param_ref %{{.*}} %arg1 : !forth.stack, f64 -> !forth.stack
 \! kernel main
 \! param DATA f64[256]
 \! param SCALE f64

--- a/test/Translation/Forth/param-declarations.forth
+++ b/test/Translation/Forth/param-declarations.forth
@@ -2,8 +2,8 @@
 
 \ Verify multi-param declarations with correct types and ordering
 \ CHECK: func.func private @main(%arg0: memref<256xi64> {forth.param_name = "DATA"}, %arg1: memref<128xi64> {forth.param_name = "WEIGHTS"})
-\ CHECK: forth.param_ref %{{.*}} "DATA"
-\ CHECK: forth.param_ref %{{.*}} "WEIGHTS"
+\ CHECK: forth.param_ref %{{.*}} %arg0 : !forth.stack, memref<256xi64> -> !forth.stack
+\ CHECK: forth.param_ref %{{.*}} %arg1 : !forth.stack, memref<128xi64> -> !forth.stack
 \! kernel main
 \! param DATA i64[256]
 \! param WEIGHTS i64[128]

--- a/test/Translation/Forth/scalar-param.forth
+++ b/test/Translation/Forth/scalar-param.forth
@@ -2,7 +2,7 @@
 
 \ Verify scalar param uses i64 argument type.
 \ CHECK: func.func private @main(%arg0: i64 {forth.param_name = "SCALE"})
-\ CHECK: forth.param_ref %{{.*}} "SCALE"
+\ CHECK: forth.param_ref %{{.*}} %arg0 : !forth.stack, i64 -> !forth.stack
 \! kernel main
 \! param SCALE i64
 SCALE


### PR DESCRIPTION
## Summary
- represent `forth.param_ref` parameters as typed SSA operands instead of string attributes
- resolve parameter names to kernel entry block arguments during Forth translation
- consume converted parameter operands directly for array, i64 scalar, and f64 scalar lowering

## Testing
- `cmake --build build --target format`
- focused lit tests (4 passed)
- `cmake --build build --target check-warpforth` (109 passed)
- `cmake --build build --target check-clang-tidy`