### PR TITLE
refactor(parser): simplify control-flow construction

### DIFF
--- a/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
+++ b/lib/Conversion/ForthToMemRef/ForthToMemRef.cpp
@@ -18,6 +18,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/RegionUtils.h"
 #include "warpforth/Dialect/Forth/ForthDialect.h"
 
 namespace mlir {
@@ -1319,6 +1320,13 @@ struct ConvertForthToMemRefPass
   void runOnOperation() override {
     auto *context = &getContext();
     auto module = getOperation();
+
+    // Dialect conversion does not rewrite unreachable blocks. Remove parser
+    // continuations before converting !forth.stack values 1:N.
+    IRRewriter rewriter(context);
+    module.walk([&](func::FuncOp funcOp) {
+      (void)eraseUnreachableBlocks(rewriter, funcOp->getRegions());
+    });
 
     ConversionTarget target(*context);
 

--- a/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
+++ b/lib/Translation/ForthToMLIR/ForthToMLIR.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Tools/mlir-translate/Translation.h"
 #include "warpforth/Dialect/Forth/ForthDialect.h"
 #include "warpforth/Translation/ForthToMLIR/ForthToMLIR.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -924,6 +925,7 @@ LogicalResult ForthParser::parseBody(Value &stack) {
       consume();
     } else if (currentToken.kind == Token::Kind::Word) {
       Location loc = getLoc();
+      llvm::SMLoc tokenLoc = currentToken.location;
       StringRef word = currentToken.text;
 
       //=== IF ===
@@ -959,10 +961,10 @@ LogicalResult ForthParser::parseBody(Value &stack) {
 
         // Pop the false-path block (from IF) - this becomes else-body start.
         if (cfStack.empty())
-          return emitError("ELSE without matching IF");
+          return emitErrorAt(tokenLoc, "ELSE without matching IF");
         auto [tag, joinBlock] = cfStack.pop_back_val();
         if (tag != CFTag::Orig)
-          return emitError("ELSE without matching IF");
+          return emitErrorAt(tokenLoc, "ELSE without matching IF");
 
         // Push merge block for THEN to pick up.
         cfStack.push_back({CFTag::Orig, mergeBlock});
@@ -977,10 +979,10 @@ LogicalResult ForthParser::parseBody(Value &stack) {
 
         // Pop the join/merge block.
         if (cfStack.empty())
-          return emitError("THEN without matching IF");
+          return emitErrorAt(tokenLoc, "THEN without matching IF");
         auto [tag, joinBlock] = cfStack.pop_back_val();
         if (tag != CFTag::Orig)
-          return emitError("THEN without matching IF");
+          return emitErrorAt(tokenLoc, "THEN without matching IF");
 
         // Branch from current block to join.
         builder.create<cf::BranchOp>(loc, joinBlock, ValueRange{stack});
@@ -1014,10 +1016,10 @@ LogicalResult ForthParser::parseBody(Value &stack) {
         auto [s1, flag] = emitPopFlag(loc, stack);
 
         if (cfStack.empty())
-          return emitError("UNTIL without matching BEGIN");
+          return emitErrorAt(tokenLoc, "UNTIL without matching BEGIN");
         auto [tag, loopBlock] = cfStack.pop_back_val();
         if (tag != CFTag::Dest)
-          return emitError("UNTIL without matching BEGIN");
+          return emitErrorAt(tokenLoc, "UNTIL without matching BEGIN");
 
         auto *exitBlock = createStackBlock(parentRegion, loc);
 
@@ -1037,10 +1039,10 @@ LogicalResult ForthParser::parseBody(Value &stack) {
         auto [s1, flag] = emitPopFlag(loc, stack);
 
         if (cfStack.empty())
-          return emitError("WHILE without matching BEGIN");
+          return emitErrorAt(tokenLoc, "WHILE without matching BEGIN");
         auto [tag, loopBlock] = cfStack.pop_back_val();
         if (tag != CFTag::Dest)
-          return emitError("WHILE without matching BEGIN");
+          return emitErrorAt(tokenLoc, "WHILE without matching BEGIN");
 
         auto *bodyBlock = createStackBlock(parentRegion, loc);
         auto *exitBlock = createStackBlock(parentRegion, loc);
@@ -1063,20 +1065,20 @@ LogicalResult ForthParser::parseBody(Value &stack) {
 
         // Pop loop header (from WHILE's re-push).
         if (cfStack.empty())
-          return emitError("REPEAT without matching WHILE");
+          return emitErrorAt(tokenLoc, "REPEAT without matching WHILE");
         auto [destTag, loopBlock] = cfStack.pop_back_val();
         if (destTag != CFTag::Dest)
-          return emitError("REPEAT without matching WHILE");
+          return emitErrorAt(tokenLoc, "REPEAT without matching WHILE");
 
         // Branch back to loop header.
         builder.create<cf::BranchOp>(loc, loopBlock, ValueRange{stack});
 
         // Pop exit block (from WHILE).
         if (cfStack.empty())
-          return emitError("REPEAT without matching WHILE");
+          return emitErrorAt(tokenLoc, "REPEAT without matching WHILE");
         auto [origTag, exitBlock] = cfStack.pop_back_val();
         if (origTag != CFTag::Orig)
-          return emitError("REPEAT without matching WHILE");
+          return emitErrorAt(tokenLoc, "REPEAT without matching WHILE");
 
         // Continue after exit.
         builder.setInsertionPointToStart(exitBlock);
@@ -1087,30 +1089,27 @@ LogicalResult ForthParser::parseBody(Value &stack) {
         consume();
 
         if (loopStack.empty()) {
-          return emitError("LEAVE without matching DO");
+          return emitErrorAt(tokenLoc, "LEAVE without matching DO");
         }
 
         Region *parentRegion = builder.getInsertionBlock()->getParent();
         auto &ctx = loopStack.back();
 
-        // Continue parsing in a dead block to avoid inserting after a
-        // terminator. Use a dummy cond_br to create a reachable dead block that
-        // carries a stack argument, keeping cf->memref type conversion
-        // consistent.
-        auto *deadBlock = createStackBlock(parentRegion, loc);
-        Value cond = builder.create<arith::ConstantOp>(
-            loc, builder.getI1Type(), builder.getBoolAttr(true));
-        builder.create<cf::CondBranchOp>(loc, cond, ctx.exit, ValueRange{stack},
-                                         deadBlock, ValueRange{stack});
+        // Branch to the loop exit, then continue parsing in an unreachable
+        // block to avoid inserting after a terminator. Give the continuation
+        // its own stack so 1:N conversion needs no predecessor operands.
+        auto *deadBlock = new Block();
+        parentRegion->push_back(deadBlock);
+        builder.create<cf::BranchOp>(loc, ctx.exit, ValueRange{stack});
         builder.setInsertionPointToStart(deadBlock);
-        stack = deadBlock->getArgument(0);
+        stack = builder.create<forth::StackOp>(loc, stackType);
 
         //=== UNLOOP ===
       } else if (word == "UNLOOP") {
         consume();
 
         if (loopStack.empty()) {
-          return emitError("UNLOOP without matching DO");
+          return emitErrorAt(tokenLoc, "UNLOOP without matching DO");
         }
 
         // No-op: loop control uses CFG blocks and a memref counter, not the
@@ -1122,7 +1121,7 @@ LogicalResult ForthParser::parseBody(Value &stack) {
         consume();
 
         if (!inWordDefinition) {
-          return emitError("EXIT outside word definition");
+          return emitErrorAt(tokenLoc, "EXIT outside word definition");
         }
 
         Region *parentRegion = builder.getInsertionBlock()->getParent();
@@ -1135,16 +1134,13 @@ LogicalResult ForthParser::parseBody(Value &stack) {
           builder.create<func::ReturnOp>(loc, returnBlock->getArgument(0));
         }
 
-        // Use a dummy cond_br to keep the dead block structurally reachable,
-        // matching the pattern used by LEAVE.
-        auto *deadBlock = createStackBlock(parentRegion, loc);
-        Value cond = builder.create<arith::ConstantOp>(
-            loc, builder.getI1Type(), builder.getBoolAttr(true));
-        builder.create<cf::CondBranchOp>(loc, cond, returnBlock,
-                                         ValueRange{stack}, deadBlock,
-                                         ValueRange{stack});
+        // Branch to the return block, then continue parsing in an unreachable
+        // block with its own stack, matching the pattern used by LEAVE.
+        auto *deadBlock = new Block();
+        parentRegion->push_back(deadBlock);
+        builder.create<cf::BranchOp>(loc, returnBlock, ValueRange{stack});
         builder.setInsertionPointToStart(deadBlock);
-        stack = deadBlock->getArgument(0);
+        stack = builder.create<forth::StackOp>(loc, stackType);
 
         //=== DO ===
       } else if (word == "DO") {
@@ -1188,7 +1184,7 @@ LogicalResult ForthParser::parseBody(Value &stack) {
         consume();
 
         if (loopStack.empty()) {
-          return emitError("LOOP without matching DO");
+          return emitErrorAt(tokenLoc, "LOOP without matching DO");
         }
 
         auto ctx = loopStack.pop_back_val();
@@ -1201,7 +1197,7 @@ LogicalResult ForthParser::parseBody(Value &stack) {
         consume();
 
         if (loopStack.empty()) {
-          return emitError("+LOOP without matching DO");
+          return emitErrorAt(tokenLoc, "+LOOP without matching DO");
         }
 
         auto ctx = loopStack.pop_back_val();
@@ -1323,8 +1319,12 @@ LogicalResult ForthParser::parseLocals(Value &stack) {
 
 LogicalResult ForthParser::parseWordDefinition() {
   Location loc = getLoc();
-  auto savedInsertionPoint = builder.saveInsertionPoint();
+  OpBuilder::InsertionGuard insertionGuard(builder);
   inWordDefinition = true;
+  auto wordDefinitionGuard = llvm::make_scope_exit([&] {
+    inWordDefinition = false;
+    localVars.clear();
+  });
 
   consume(); // consume ':'
 
@@ -1366,12 +1366,6 @@ LogicalResult ForthParser::parseWordDefinition() {
   wordDefs.insert(wordName);
 
   consume(); // consume ';'
-
-  inWordDefinition = false;
-  localVars.clear();
-
-  // Restore insertion point
-  builder.restoreInsertionPoint(savedInsertionPoint);
   return success();
 }
 

--- a/test/Pipeline/exit.forth
+++ b/test/Pipeline/exit.forth
@@ -1,5 +1,8 @@
 \ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --warpforth-pipeline | %FileCheck %s
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --convert-forth-to-memref --canonicalize | %FileCheck %s --check-prefix=MID --implicit-check-not="arith.constant true"
 \ CHECK: gpu.binary @warpforth_module
+\ MID-LABEL: func.func private @DO_EXIT
+\ MID-COUNT-2: return
 
 \! kernel main
 \! param DATA i64[4]

--- a/test/Pipeline/leave.forth
+++ b/test/Pipeline/leave.forth
@@ -1,5 +1,5 @@
 \ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --warpforth-pipeline | %FileCheck %s
-\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --convert-forth-to-memref --convert-scf-to-cf --convert-forth-to-gpu | %FileCheck %s --check-prefix=MID
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt --convert-forth-to-memref --convert-scf-to-cf --convert-forth-to-gpu | %FileCheck %s --check-prefix=MID --implicit-check-not="arith.constant true"
 
 \ Verify that LEAVE through the full pipeline produces a gpu.binary
 \ CHECK: gpu.binary @warpforth_module
@@ -8,7 +8,6 @@
 \ MID: gpu.module @warpforth_module
 \ MID: gpu.func @main(%arg0: memref<4xi64> {forth.param_name = "DATA"}) kernel
 \ MID: cf.br
-\ MID: cf.cond_br
 \ MID: gpu.return
 
 \! kernel main

--- a/test/Translation/Forth/else-without-if-error.forth
+++ b/test/Translation/Forth/else-without-if-error.forth
@@ -1,4 +1,4 @@
 \ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
-\ CHECK: ELSE without matching IF
+\ CHECK: {{.*}}else-without-if-error.forth:4:1: error: ELSE without matching IF
 \! kernel main
 ELSE

--- a/test/Translation/Forth/exit-outside-word-error.forth
+++ b/test/Translation/Forth/exit-outside-word-error.forth
@@ -1,4 +1,4 @@
 \ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
-\ CHECK: EXIT outside word definition
+\ CHECK: {{.*}}exit-outside-word-error.forth:4:1: error: EXIT outside word definition
 \! kernel main
 EXIT

--- a/test/Translation/Forth/exit.forth
+++ b/test/Translation/Forth/exit.forth
@@ -3,7 +3,7 @@
 \ CHECK: func.func private @EARLY_EXIT(%[[A:.*]]: !forth.stack) -> !forth.stack
 \ CHECK:   cf.cond_br %{{.*}}, ^[[THEN:bb.*]](%{{.*}}), ^[[JOIN:bb.*]](%{{.*}})
 \ CHECK: ^[[THEN]](%[[T:.*]]: !forth.stack):
-\ CHECK:   cf.cond_br %true, ^[[RET:bb.*]](%[[T]]{{.*}}), ^[[DEAD:bb.*]](%[[T]]
+\ CHECK:   cf.br ^[[RET:bb.*]](%[[T]] : !forth.stack)
 \ CHECK: ^[[JOIN]](%{{.*}}: !forth.stack):
 \ CHECK:   return %{{.*}} : !forth.stack
 \ CHECK: ^[[RET]](%[[R:.*]]: !forth.stack):

--- a/test/Translation/Forth/if-until-mismatch-error.forth
+++ b/test/Translation/Forth/if-until-mismatch-error.forth
@@ -1,4 +1,4 @@
 \ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
-\ CHECK: UNTIL without matching BEGIN
+\ CHECK: {{.*}}if-until-mismatch-error.forth:4:4: error: UNTIL without matching BEGIN
 \! kernel main
 IF UNTIL

--- a/test/Translation/Forth/leave-conditional.forth
+++ b/test/Translation/Forth/leave-conditional.forth
@@ -16,7 +16,7 @@
 
 \ LEAVE branch: unconditional jump to exit
 \ CHECK:     ^bb[[LEAVE]](%{{.*}}: !forth.stack):
-\ CHECK:       cf.cond_br %true, ^bb[[EXIT]](%{{.*}} : !forth.stack), ^bb[[DEAD:[0-9]+]](%{{.*}} : !forth.stack)
+\ CHECK:       cf.br ^bb[[EXIT]](%{{.*}} : !forth.stack)
 
 \ Join (THEN merge): 1 DROP, crossing test, loop back to body or exit
 \ CHECK:     ^bb[[JOIN]](%{{.*}}: !forth.stack):
@@ -24,8 +24,9 @@
 \ CHECK:       arith.cmpi slt
 \ CHECK:       cf.cond_br
 
-\ Dead block from LEAVE
-\ CHECK:     ^bb[[DEAD]](%{{.*}}: !forth.stack):
+\ Unreachable continuation from LEAVE
+\ CHECK:     ^bb{{[0-9]+}}:  // no predecessors
+\ CHECK:       forth.stack
 \ CHECK:       cf.br ^bb[[JOIN]]
 
 \! kernel main

--- a/test/Translation/Forth/leave-without-do-error.forth
+++ b/test/Translation/Forth/leave-without-do-error.forth
@@ -1,4 +1,4 @@
 \ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
-\ CHECK: {{.*}}then-without-if-error.forth:4:1: error: THEN without matching IF
+\ CHECK: {{.*}}leave-without-do-error.forth:4:1: error: LEAVE without matching DO
 \! kernel main
-THEN
+LEAVE

--- a/test/Translation/Forth/leave.forth
+++ b/test/Translation/Forth/leave.forth
@@ -7,8 +7,7 @@
 \ CHECK-NEXT:  %[[S2:.*]] = forth.constant %[[S1]](0 : i64) : !forth.stack -> !forth.stack
 \ CHECK:       cf.br ^bb1(%{{.*}} : !forth.stack)
 \ CHECK:     ^bb1(%[[B1:.*]]: !forth.stack):
-\ CHECK-NEXT:  %[[TRUE:.*]] = arith.constant true
-\ CHECK-NEXT:  cf.cond_br %[[TRUE]], ^bb[[EXIT:[0-9]+]](%[[B1]] : !forth.stack), ^bb{{[0-9]+}}(%[[B1]] : !forth.stack)
+\ CHECK-NEXT:  cf.br ^bb[[EXIT:[0-9]+]](%[[B1]] : !forth.stack)
 \ CHECK:     ^bb[[EXIT]](%[[B3:.*]]: !forth.stack):
 \ CHECK-NEXT:  return
 

--- a/test/Translation/Forth/repeat-without-while-error.forth
+++ b/test/Translation/Forth/repeat-without-while-error.forth
@@ -1,4 +1,4 @@
 \ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
-\ CHECK: REPEAT without matching WHILE
+\ CHECK: {{.*}}repeat-without-while-error.forth:4:1: error: REPEAT without matching WHILE
 \! kernel main
 REPEAT

--- a/test/Translation/Forth/unloop-exit.forth
+++ b/test/Translation/Forth/unloop-exit.forth
@@ -11,7 +11,7 @@
 \ CHECK: ^bb[[#EXIT:]](%{{.*}}: !forth.stack):
 \ CHECK: return
 \ CHECK: ^bb[[#THEN]](%[[T:.*]]: !forth.stack):
-\ CHECK: cf.cond_br %true, ^bb[[#RET:]](%[[T]]{{.*}})
+\ CHECK: cf.br ^bb[[#RET:]](%[[T]] : !forth.stack)
 \ CHECK: ^bb[[#RET]](%[[R:.*]]: !forth.stack):
 \ CHECK: return %[[R]] : !forth.stack
 

--- a/test/Translation/Forth/while-without-begin-error.forth
+++ b/test/Translation/Forth/while-without-begin-error.forth
@@ -1,4 +1,4 @@
 \ RUN: %not %warpforth-translate --forth-to-mlir %s 2>&1 | %FileCheck %s
-\ CHECK: WHILE without matching BEGIN
+\ CHECK: {{.*}}while-without-begin-error.forth:4:1: error: WHILE without matching BEGIN
 \! kernel main
 WHILE


### PR DESCRIPTION
## Summary
- replace constant-true LEAVE and EXIT conditionals with direct branches and self-contained unreachable parser continuations
- discard unreachable continuations before Forth stack 1:N conversion and report control mismatches at the offending token
- use RAII guards for word-definition insertion point and parser state

## Testing
- `cmake --build build --target format`
- targeted lit suite (14 tests)
- `cmake --build build --target check-warpforth` (110 tests)
- `cmake --build build --target check-clang-tidy`