### PR TITLE
feat(pipeline): add target options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ These tools can be composed for debugging or inspecting intermediate stages:
   ./build/bin/warpforth-translate --mlir-to-ptx
 ```
 
+The pipeline accepts standard MLIR pipeline options for its NVVM target and
+output format. For example, to target Ampere while retaining textual PTX
+output:
+
+```bash
+./build/bin/warpforth-opt \
+  --pass-pipeline='builtin.module(warpforth-pipeline{chip=sm_80 features=+ptx70 opt-level=3 compilation-target=isa})' \
+  kernel.mlir
+```
+
+Available options are `chip` (default `sm_70`), `features` (default `+ptx60`),
+`libdevice` (the configured libdevice path by default), `opt-level` (`0`, `1`,
+`2`, or `3`; default `2`), and `compilation-target` (`llvm`, `isa`, `bin`, or
+`fatbin`; default `isa`, textual PTX).
+
 ## Language Reference
 
 WarpForth supports stack operations, integer and float arithmetic, control flow, global and shared memory access, reduced-width memory types, user-defined words with local variables, and GPU-specific operations.

--- a/include/warpforth/Conversion/Passes.h
+++ b/include/warpforth/Conversion/Passes.h
@@ -7,19 +7,37 @@
 #ifndef WARPFORTH_CONVERSION_PASSES_H
 #define WARPFORTH_CONVERSION_PASSES_H
 
+#include "mlir/Dialect/GPU/IR/CompilationInterfaces.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassOptions.h"
+#include "llvm/Support/CodeGen.h"
 #include <memory>
+#include <string>
 
 namespace mlir {
 class OpPassManager;
 
 namespace warpforth {
 
+/// Target configuration for the WarpForth compilation pipeline.
+struct WarpForthPipelineOptions
+    : public PassPipelineOptions<WarpForthPipelineOptions> {
+  WarpForthPipelineOptions();
+
+  PassOptions::Option<std::string> chip;
+  PassOptions::Option<std::string> features;
+  PassOptions::Option<std::string> libdevicePath;
+  PassOptions::Option<llvm::CodeGenOptLevel> optLevel;
+  PassOptions::Option<gpu::CompilationTarget> compilationTarget;
+};
+
 /// Register all conversion passes.
 void registerConversionPasses();
 
 /// Build the WarpForth compilation pipeline (Forth to PTX).
 void buildWarpForthPipeline(OpPassManager &pm);
+void buildWarpForthPipeline(OpPassManager &pm,
+                            const WarpForthPipelineOptions &options);
 
 } // namespace warpforth
 } // namespace mlir

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -22,7 +22,40 @@
 namespace mlir {
 namespace warpforth {
 
-void buildWarpForthPipeline(OpPassManager &pm) {
+WarpForthPipelineOptions::WarpForthPipelineOptions()
+    : chip(*this, "chip", llvm::cl::desc("NVVM target chip"),
+           llvm::cl::init("sm_70")),
+      features(*this, "features", llvm::cl::desc("NVVM target features"),
+               llvm::cl::init("+ptx60")),
+      libdevicePath(*this, "libdevice",
+                    llvm::cl::desc("Path to the CUDA libdevice bitcode"),
+                    llvm::cl::init(WARPFORTH_LIBDEVICE_PATH)),
+      optLevel(
+          *this, "opt-level",
+          llvm::cl::desc("NVVM target optimization level (0, 1, 2, or 3)"),
+          llvm::cl::init(llvm::CodeGenOptLevel::Default),
+          llvm::cl::values(
+              clEnumValN(llvm::CodeGenOptLevel::None, "0", "No optimization"),
+              clEnumValN(llvm::CodeGenOptLevel::Less, "1", "Less optimization"),
+              clEnumValN(llvm::CodeGenOptLevel::Default, "2",
+                         "Default optimization"),
+              clEnumValN(llvm::CodeGenOptLevel::Aggressive, "3",
+                         "Aggressive optimization"))),
+      compilationTarget(
+          *this, "compilation-target",
+          llvm::cl::desc("GPU output format (llvm, isa, bin, or fatbin)"),
+          llvm::cl::init(gpu::CompilationTarget::Assembly),
+          llvm::cl::values(clEnumValN(gpu::CompilationTarget::Offload, "llvm",
+                                      "LLVM bitcode"),
+                           clEnumValN(gpu::CompilationTarget::Assembly, "isa",
+                                      "Target assembly"),
+                           clEnumValN(gpu::CompilationTarget::Binary, "bin",
+                                      "Target binary"),
+                           clEnumValN(gpu::CompilationTarget::Fatbin, "fatbin",
+                                      "Fat binary"))) {}
+
+void buildWarpForthPipeline(OpPassManager &pm,
+                            const WarpForthPipelineOptions &options) {
   // Stage 1: Lower Forth to MemRef (CF ops pass through as-is)
   pm.addPass(createConvertForthToMemRefPass());
 
@@ -32,10 +65,13 @@ void buildWarpForthPipeline(OpPassManager &pm) {
   // Stage 3: Normalize MemRefs for GPU
   pm.addPass(createCanonicalizerPass());
 
-  // Stage 4: Attach NVVM target to GPU modules (sm_70 = Volta architecture)
+  // Stage 4: Attach the configured NVVM target to GPU modules
   GpuNVVMAttachTargetOptions nvvmOptions;
-  nvvmOptions.chip = "sm_70";
-  nvvmOptions.linkLibs.push_back(WARPFORTH_LIBDEVICE_PATH);
+  nvvmOptions.chip = options.chip.getValue();
+  nvvmOptions.features = options.features.getValue();
+  nvvmOptions.optLevel = static_cast<unsigned>(options.optLevel.getValue());
+  if (!options.libdevicePath.getValue().empty())
+    nvvmOptions.linkLibs.push_back(options.libdevicePath.getValue());
   pm.addPass(createGpuNVVMAttachTarget(nvvmOptions));
 
   // Stage 5: Lower GPU to NVVM with bare pointers
@@ -55,8 +91,13 @@ void buildWarpForthPipeline(OpPassManager &pm) {
 
   // Stage 9: Compile GPU module to PTX binary
   GpuModuleToBinaryPassOptions binaryOptions;
-  binaryOptions.compilationTarget = "isa"; // Output PTX assembly
+  binaryOptions.compilationTarget =
+      gpu::stringifyCompilationTarget(options.compilationTarget.getValue());
   pm.addPass(createGpuModuleToBinaryPass(binaryOptions));
+}
+
+void buildWarpForthPipeline(OpPassManager &pm) {
+  buildWarpForthPipeline(pm, WarpForthPipelineOptions());
 }
 
 void registerConversionPasses() {
@@ -67,9 +108,11 @@ void registerConversionPasses() {
       []() -> std::unique_ptr<Pass> { return createConvertForthToGPUPass(); });
 
   // Register WarpForth pipeline
-  PassPipelineRegistration<>("warpforth-pipeline",
-                             "WarpForth compilation pipeline (Forth to PTX)",
-                             buildWarpForthPipeline);
+  PassPipelineRegistration<WarpForthPipelineOptions>(
+      "warpforth-pipeline", "WarpForth compilation pipeline (Forth to PTX)",
+      [](OpPassManager &pm, const WarpForthPipelineOptions &options) {
+        buildWarpForthPipeline(pm, options);
+      });
 }
 
 } // namespace warpforth

--- a/test/Pipeline/target-options.forth
+++ b/test/Pipeline/target-options.forth
@@ -1,0 +1,10 @@
+\ RUN: %warpforth-translate --forth-to-mlir %s | %warpforth-opt '--pass-pipeline=builtin.module(warpforth-pipeline{chip=sm_80 opt-level=3 compilation-target=isa})' --mlir-print-ir-after=nvvm-attach-target --mlir-disable-threading 2>&1 | %FileCheck %s
+\ RUN: %warpforth-translate --forth-to-mlir %s | %not %warpforth-opt '--pass-pipeline=builtin.module(warpforth-pipeline{opt-level=4})' 2>&1 | %FileCheck %s --check-prefix=BAD-OPT
+\ RUN: %warpforth-translate --forth-to-mlir %s | %not %warpforth-opt '--pass-pipeline=builtin.module(warpforth-pipeline{compilation-target=bogus})' 2>&1 | %FileCheck %s --check-prefix=BAD-FORMAT
+
+\! kernel main
+42
+
+\ CHECK: #nvvm.target<O = 3, chip = "sm_80"
+\ BAD-OPT: for the --opt-level option: Cannot find option named '4'!
+\ BAD-FORMAT: for the --compilation-target option: Cannot find option named 'bogus'!


### PR DESCRIPTION
## Summary
- expose NVVM chip, features, libdevice, optimization level, and compilation target through typed MLIR pipeline options
- preserve the existing programmatic builder and all current target defaults
- document standard pass-pipeline syntax and test a nondefault chip without requiring GPU hardware

## Testing
- `cmake --build build --target format`
- `python3 /usr/lib/llvm-20/build/utils/lit/lit.py -v --filter='Pipeline/(target-options|full-pipeline)' build/test`
- `cmake --build build --target check-warpforth` (110 tests passed)
- `cmake --build build --target check-clang-tidy`