### PR TITLE
fix(runner): harden parsing and CUDA resources

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,6 @@ configure_file(
 
 add_custom_target(check-warpforth
   COMMAND ${LIT_COMMAND} ${CMAKE_CURRENT_BINARY_DIR} -v
-  DEPENDS warpforth-translate warpforth-opt
+  DEPENDS warpforth-translate warpforth-opt warpforth-runner-validate
   COMMENT "Running WarpForth lit tests"
 )

--- a/test/Runner/validation.test
+++ b/test/Runner/validation.test
@@ -1,0 +1,20 @@
+# RUN: %not %warpforth-runner-validate kernel.ptx --kernel main --param 'i64[]:1,2x' 2>&1 | %FileCheck %s --check-prefix=INT-TRAILING
+# RUN: %not %warpforth-runner-validate kernel.ptx --kernel main --param 'i64[]:9223372036854775808' 2>&1 | %FileCheck %s --check-prefix=INT-RANGE
+# RUN: %not %warpforth-runner-validate kernel.ptx --kernel main --param 'i64[]:-9223372036854775809' 2>&1 | %FileCheck %s --check-prefix=INT-RANGE
+# RUN: %not %warpforth-runner-validate kernel.ptx --kernel main --param 'f64[]:1.5x' 2>&1 | %FileCheck %s --check-prefix=FLOAT-TRAILING
+# RUN: %not %warpforth-runner-validate kernel.ptx --kernel main --param 'f64[]:1e9999' 2>&1 | %FileCheck %s --check-prefix=FLOAT-RANGE
+# RUN: %not %warpforth-runner-validate kernel.ptx --kernel main --param 'i64[]:1,,2' 2>&1 | %FileCheck %s --check-prefix=EMPTY
+# RUN: %not %warpforth-runner-validate kernel.ptx --kernel main --param 'f64[]:1,' 2>&1 | %FileCheck %s --check-prefix=EMPTY
+# RUN: %not %warpforth-runner-validate kernel.ptx --kernel main --param 'i64[]:1,2' --output-count 3 2>&1 | %FileCheck %s --check-prefix=COUNT-LARGE
+# RUN: %not %warpforth-runner-validate kernel.ptx --kernel main --param 'i64[]:1,2' --output-count -1 2>&1 | %FileCheck %s --check-prefix=COUNT-NEGATIVE
+# RUN: %not %warpforth-runner-validate kernel.ptx --kernel main --param 'i64[]:-9223372036854775808,9223372036854775807' --param 'f64:1.25e+2' --output-count 0 2>&1 | %FileCheck %s --check-prefix=VALID
+# RUN: %not %warpforth-runner-validate kernel.ptx --kernel main --param 'i64[]:+1,-2' --output-count 2 2>&1 | %FileCheck %s --check-prefix=VALID
+
+# INT-TRAILING: Error: invalid integer value '2x' in --param i64[]:1,2x: trailing characters
+# INT-RANGE: value is out of range for i64
+# FLOAT-TRAILING: Error: invalid float value '1.5x' in --param f64[]:1.5x: trailing characters
+# FLOAT-RANGE: Error: invalid float value '1e9999' in --param f64[]:1e9999: value is out of range for f64
+# EMPTY: empty comma-separated field
+# COUNT-LARGE: Error: --output-count 3 exceeds selected output array size 2
+# COUNT-NEGATIVE: Error: --output-count must not be negative
+# VALID: Error: CUDA execution unavailable in host-validation build

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -3,7 +3,7 @@ import lit.formats
 
 config.name = "WarpForth"
 config.test_format = lit.formats.ShTest(True)
-config.suffixes = [".forth", ".mlir"]
+config.suffixes = [".forth", ".mlir", ".test"]
 config.test_source_root = os.path.dirname(__file__)
 
 # Tool substitutions
@@ -12,6 +12,9 @@ config.substitutions.append(
 )
 config.substitutions.append(
     ("%warpforth-opt", os.path.join(config.warpforth_bin_root, "bin", "warpforth-opt"))
+)
+config.substitutions.append(
+    ("%warpforth-runner-validate", os.path.join(config.warpforth_bin_root, "bin", "warpforth-runner-validate"))
 )
 config.substitutions.append(
     ("%FileCheck", config.filecheck_path)

--- a/tools/warpforth-runner/CMakeLists.txt
+++ b/tools/warpforth-runner/CMakeLists.txt
@@ -1,5 +1,12 @@
 find_package(CUDAToolkit QUIET)
 
+add_executable(warpforth-runner-validate EXCLUDE_FROM_ALL warpforth-runner.cpp)
+target_compile_definitions(warpforth-runner-validate
+  PRIVATE WARPFORTH_RUNNER_HOST_VALIDATION)
+target_compile_features(warpforth-runner-validate PRIVATE cxx_std_17)
+set_target_properties(warpforth-runner-validate PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${LLVM_RUNTIME_OUTPUT_INTDIR})
+
 if(CUDAToolkit_FOUND)
   add_executable(warpforth-runner warpforth-runner.cpp)
   target_link_libraries(warpforth-runner PRIVATE CUDA::cuda_driver)

--- a/tools/warpforth-runner/warpforth-runner.cpp
+++ b/tools/warpforth-runner/warpforth-runner.cpp
@@ -9,37 +9,31 @@
 ///       --grid 4,1,1 --block 64,1,1 --kernel main \
 ///       --output-param 0 --output-count 3
 
+#ifndef WARPFORTH_RUNNER_HOST_VALIDATION
 #include <cuda.h>
+#endif
 
+#include <cerrno>
 #include <charconv>
+#include <cinttypes>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <system_error>
 #include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 
-#define CHECK_CU(call)                                                         \
-  do {                                                                         \
-    CUresult err = (call);                                                     \
-    if (err != CUDA_SUCCESS) {                                                 \
-      const char *errStr = nullptr;                                            \
-      cuGetErrorString(err, &errStr);                                          \
-      std::cerr << "CUDA error at " << __FILE__ << ":" << __LINE__ << ": "     \
-                << (errStr ? errStr : "unknown") << "\n";                      \
-      exit(1);                                                                 \
-    }                                                                          \
-  } while (0)
-
 template <typename T> struct ArrayParam {
   std::vector<T> values;
-  CUdeviceptr devicePtr = 0;
 };
 
 template <typename T> struct ScalarParam {
@@ -49,17 +43,294 @@ template <typename T> struct ScalarParam {
 using Param = std::variant<ArrayParam<int64_t>, ArrayParam<double>,
                            ScalarParam<int64_t>, ScalarParam<double>>;
 
-template <typename T> static void allocDevice(ArrayParam<T> &arr) {
-  size_t bytes = arr.values.size() * sizeof(T);
-  CHECK_CU(cuMemAlloc(&arr.devicePtr, bytes));
-  CHECK_CU(cuMemcpyHtoD(arr.devicePtr, arr.values.data(), bytes));
+static std::runtime_error paramError(std::string_view kind,
+                                     std::string_view token,
+                                     std::string_view param,
+                                     std::string_view reason) {
+  std::ostringstream message;
+  message << "invalid " << kind << " value '" << token << "' in --param "
+          << param << ": " << reason;
+  return std::runtime_error(message.str());
+}
+
+static int64_t parseI64(std::string_view token, std::string_view param) {
+  if (token.empty())
+    throw paramError("integer", token, param, "empty value");
+
+  std::string value(token);
+  char *end = nullptr;
+  errno = 0;
+  intmax_t parsed = std::strtoimax(value.c_str(), &end, 10);
+  if (end == value.c_str())
+    throw paramError("integer", token, param, "expected an integer");
+  if (errno == ERANGE || parsed < INT64_MIN || parsed > INT64_MAX)
+    throw paramError("integer", token, param, "value is out of range for i64");
+  if (end != value.c_str() + value.size())
+    throw paramError("integer", token, param, "trailing characters");
+  return static_cast<int64_t>(parsed);
+}
+
+static double parseF64(std::string_view token, std::string_view param) {
+  if (token.empty())
+    throw paramError("float", token, param, "empty value");
+
+  std::string value(token);
+  char *end = nullptr;
+  errno = 0;
+  double parsed = std::strtod(value.c_str(), &end);
+  if (end == value.c_str())
+    throw paramError("float", token, param, "expected a float");
+  if (errno == ERANGE)
+    throw paramError("float", token, param, "value is out of range for f64");
+  if (end != value.c_str() + value.size())
+    throw paramError("float", token, param, "trailing characters");
+  return parsed;
+}
+
+template <typename T, typename Parse>
+static std::vector<T> parseArrayValues(std::string_view values,
+                                       std::string_view param, Parse parse) {
+  std::vector<T> result;
+  size_t start = 0;
+  while (true) {
+    size_t comma = values.find(',', start);
+    std::string_view token = values.substr(start, comma - start);
+    if (token.empty())
+      throw paramError(std::is_same_v<T, int64_t> ? "integer" : "float", token,
+                       param, "empty comma-separated field");
+    result.push_back(parse(token, param));
+    if (comma == std::string_view::npos)
+      break;
+    start = comma + 1;
+  }
+  return result;
+}
+
+static Param parseParam(std::string_view input) {
+  size_t colon = input.find(':');
+  if (colon == std::string_view::npos)
+    throw std::runtime_error(
+        "--param requires type prefix (e.g. i64:42 or f64[]:1.0,2.0), got: " +
+        std::string(input));
+
+  std::string_view type = input.substr(0, colon);
+  std::string_view values = input.substr(colon + 1);
+  if (values.empty())
+    throw std::runtime_error("--param requires at least one value, got: " +
+                             std::string(input));
+
+  if (type == "i64[]")
+    return ArrayParam<int64_t>{
+        parseArrayValues<int64_t>(values, input, parseI64)};
+  if (type == "f64[]")
+    return ArrayParam<double>{
+        parseArrayValues<double>(values, input, parseF64)};
+
+  if (values.find(',') != std::string_view::npos)
+    throw std::runtime_error("scalar param expects exactly one value, got: " +
+                             std::string(input));
+  if (type == "i64")
+    return ScalarParam<int64_t>{parseI64(values, input)};
+  if (type == "f64")
+    return ScalarParam<double>{parseF64(values, input)};
+
+  throw std::runtime_error(
+      "unsupported param type '" + std::string(type) +
+      "' (expected i64, i64[], f64, or f64[]), got: " + std::string(input));
+}
+
+struct Dims {
+  unsigned x = 1, y = 1, z = 1;
+};
+
+static int parseIntArg(std::string_view input, std::string_view option) {
+  int value = 0;
+  auto [end, error] =
+      std::from_chars(input.data(), input.data() + input.size(), value);
+  if (error != std::errc{} || end != input.data() + input.size())
+    throw std::runtime_error(std::string(option) +
+                             " expects an integer, got: " + std::string(input));
+  return value;
+}
+
+static Dims parseDims(std::string_view input) {
+  Dims dims;
+  const char *current = input.data();
+  const char *end = input.data() + input.size();
+
+  auto parseError = [&]() {
+    throw std::runtime_error("expected 3 comma-separated values, got: " +
+                             std::string(input));
+  };
+
+  auto [firstEnd, firstError] = std::from_chars(current, end, dims.x);
+  if (firstError != std::errc{} || firstEnd == end || *firstEnd != ',')
+    parseError();
+
+  auto [secondEnd, secondError] = std::from_chars(firstEnd + 1, end, dims.y);
+  if (secondError != std::errc{} || secondEnd == end || *secondEnd != ',')
+    parseError();
+
+  auto [thirdEnd, thirdError] = std::from_chars(secondEnd + 1, end, dims.z);
+  if (thirdError != std::errc{} || thirdEnd != end)
+    parseError();
+
+  return dims;
+}
+
+static bool isScalar(const Param &param) {
+  return std::holds_alternative<ScalarParam<int64_t>>(param) ||
+         std::holds_alternative<ScalarParam<double>>(param);
+}
+
+static size_t arraySize(const Param &param) {
+  if (auto *array = std::get_if<ArrayParam<int64_t>>(&param))
+    return array->values.size();
+  return std::get<ArrayParam<double>>(param).values.size();
+}
+
+#ifndef WARPFORTH_RUNNER_HOST_VALIDATION
+static void checkCu(CUresult result, std::string_view operation) {
+  if (result == CUDA_SUCCESS)
+    return;
+  const char *description = nullptr;
+  cuGetErrorString(result, &description);
+  throw std::runtime_error(std::string(operation) + " failed: " +
+                           (description ? description : "unknown CUDA error"));
+}
+
+static void reportCleanupError(CUresult result, std::string_view operation) {
+  if (result == CUDA_SUCCESS)
+    return;
+  const char *description = nullptr;
+  cuGetErrorString(result, &description);
+  std::cerr << "CUDA cleanup error: " << operation
+            << " failed: " << (description ? description : "unknown CUDA error")
+            << "\n";
+}
+
+class CudaContext {
+public:
+  static CudaContext create(CUdevice device) {
+    CUcontext context = nullptr;
+    checkCu(cuCtxCreate(&context, 0, device), "cuCtxCreate");
+    return CudaContext(context);
+  }
+
+  CudaContext(const CudaContext &) = delete;
+  CudaContext &operator=(const CudaContext &) = delete;
+  CudaContext(CudaContext &&other) noexcept
+      : context_(std::exchange(other.context_, nullptr)) {}
+  CudaContext &operator=(CudaContext &&other) noexcept {
+    if (this != &other) {
+      reset();
+      context_ = std::exchange(other.context_, nullptr);
+    }
+    return *this;
+  }
+  ~CudaContext() { reset(); }
+
+private:
+  explicit CudaContext(CUcontext context) : context_(context) {}
+  void reset() noexcept {
+    if (context_) {
+      reportCleanupError(cuCtxDestroy(context_), "cuCtxDestroy");
+      context_ = nullptr;
+    }
+  }
+
+  CUcontext context_ = nullptr;
+};
+
+class CudaModule {
+public:
+  static CudaModule load(const char *ptx) {
+    CUmodule module = nullptr;
+    checkCu(cuModuleLoadData(&module, ptx), "cuModuleLoadData");
+    return CudaModule(module);
+  }
+
+  CudaModule(const CudaModule &) = delete;
+  CudaModule &operator=(const CudaModule &) = delete;
+  CudaModule(CudaModule &&other) noexcept
+      : module_(std::exchange(other.module_, nullptr)) {}
+  CudaModule &operator=(CudaModule &&other) noexcept {
+    if (this != &other) {
+      reset();
+      module_ = std::exchange(other.module_, nullptr);
+    }
+    return *this;
+  }
+  ~CudaModule() { reset(); }
+
+  CUmodule get() const { return module_; }
+
+private:
+  explicit CudaModule(CUmodule module) : module_(module) {}
+  void reset() noexcept {
+    if (module_) {
+      reportCleanupError(cuModuleUnload(module_), "cuModuleUnload");
+      module_ = nullptr;
+    }
+  }
+
+  CUmodule module_ = nullptr;
+};
+
+class DeviceAllocation {
+public:
+  DeviceAllocation(const void *source, size_t bytes) {
+    checkCu(cuMemAlloc(&pointer_, bytes), "cuMemAlloc");
+    try {
+      checkCu(cuMemcpyHtoD(pointer_, source, bytes), "cuMemcpyHtoD");
+    } catch (...) {
+      reset();
+      throw;
+    }
+  }
+
+  DeviceAllocation(const DeviceAllocation &) = delete;
+  DeviceAllocation &operator=(const DeviceAllocation &) = delete;
+  DeviceAllocation(DeviceAllocation &&other) noexcept
+      : pointer_(std::exchange(other.pointer_, 0)) {}
+  DeviceAllocation &operator=(DeviceAllocation &&other) noexcept {
+    if (this != &other) {
+      reset();
+      pointer_ = std::exchange(other.pointer_, 0);
+    }
+    return *this;
+  }
+  ~DeviceAllocation() { reset(); }
+
+  CUdeviceptr get() const { return pointer_; }
+
+private:
+  void reset() noexcept {
+    if (pointer_ != 0) {
+      reportCleanupError(cuMemFree(pointer_), "cuMemFree");
+      pointer_ = 0;
+    }
+  }
+
+  CUdeviceptr pointer_ = 0;
+};
+
+static std::string readFile(std::string_view path) {
+  std::ifstream file(std::string(path), std::ios::binary);
+  if (!file)
+    throw std::runtime_error("cannot open " + std::string(path));
+  std::ostringstream contents;
+  contents << file.rdbuf();
+  return contents.str();
 }
 
 template <typename T>
-static void printOutput(ArrayParam<T> &arr, size_t count) {
-  std::vector<T> output(arr.values.size());
-  CHECK_CU(cuMemcpyDtoH(output.data(), arr.devicePtr,
-                        arr.values.size() * sizeof(T)));
+static void printOutput(const ArrayParam<T> &array, CUdeviceptr devicePointer,
+                        size_t count) {
+  std::vector<T> output(array.values.size());
+  checkCu(cuMemcpyDtoH(output.data(), devicePointer,
+                       array.values.size() * sizeof(T)),
+          "cuMemcpyDtoH");
   for (size_t i = 0; i < count; ++i) {
     if (i > 0)
       std::cout << ",";
@@ -70,183 +341,42 @@ static void printOutput(ArrayParam<T> &arr, size_t count) {
   }
   std::cout << "\n";
 }
+#endif
 
-static void *kernelArgPtr(Param &p) {
-  if (auto *a = std::get_if<ArrayParam<int64_t>>(&p))
-    return &a->devicePtr;
-  if (auto *a = std::get_if<ArrayParam<double>>(&p))
-    return &a->devicePtr;
-  if (auto *s = std::get_if<ScalarParam<int64_t>>(&p))
-    return &s->value;
-  return &std::get<ScalarParam<double>>(p).value;
-}
-
-static bool isScalar(const Param &p) {
-  return std::holds_alternative<ScalarParam<int64_t>>(p) ||
-         std::holds_alternative<ScalarParam<double>>(p);
-}
-
-struct Dims {
-  unsigned x = 1, y = 1, z = 1;
-};
-
-static int parseIntArg(std::string_view s, std::string_view optName) {
-  int value = 0;
-  auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value);
-  if (ec != std::errc{} || ptr != s.data() + s.size()) {
-    std::cerr << "Error: " << optName << " expects an integer, got: " << s
-              << "\n";
-    exit(1);
-  }
-  return value;
-}
-
-static Dims parseDims(std::string_view s) {
-  Dims d;
-  const char *p = s.data();
-  const char *end = s.data() + s.size();
-
-  auto dimsErr = [&]() {
-    std::cerr << "Error: expected 3 comma-separated values, got: " << s << "\n";
-    exit(1);
-  };
-
-  auto [p1, ec1] = std::from_chars(p, end, d.x);
-  if (ec1 != std::errc{} || p1 == end || *p1 != ',')
-    dimsErr();
-
-  auto [p2, ec2] = std::from_chars(p1 + 1, end, d.y);
-  if (ec2 != std::errc{} || p2 == end || *p2 != ',')
-    dimsErr();
-
-  auto [p3, ec3] = std::from_chars(p2 + 1, end, d.z);
-  if (ec3 != std::errc{} || p3 != end)
-    dimsErr();
-
-  return d;
-}
-
-static Param parseParam(std::string_view s) {
-  std::string input(s);
-
-  auto colonPos = input.find(':');
-  if (colonPos == std::string::npos) {
-    std::cerr << "Error: --param requires type prefix (e.g. i64:42 or "
-                 "f64[]:1.0,2.0), got: "
-              << s << "\n";
-    exit(1);
-  }
-
-  std::string typePrefix = input.substr(0, colonPos);
-  std::string valueStr = input.substr(colonPos + 1);
-
-  if (valueStr.empty()) {
-    std::cerr << "Error: --param requires at least one value, got: " << s
-              << "\n";
-    exit(1);
-  }
-
-  // Parse comma-separated values into a typed vector
-  auto parseValues = [&](auto convert) {
-    using T = decltype(convert(std::string{}));
-    std::vector<T> vals;
-    std::istringstream iss(valueStr);
-    std::string token;
-    while (std::getline(iss, token, ','))
-      vals.push_back(convert(token));
-    return vals;
-  };
-
-  auto toI64 = [&](const std::string &tok) -> int64_t {
-    try {
-      return std::stoll(tok);
-    } catch (const std::exception &) {
-      std::cerr << "Error: invalid integer value '" << tok << "' in --param "
-                << s << "\n";
-      exit(1);
-    }
-  };
-  auto toF64 = [&](const std::string &tok) -> double {
-    try {
-      return std::stod(tok);
-    } catch (const std::exception &) {
-      std::cerr << "Error: invalid float value '" << tok << "' in --param " << s
-                << "\n";
-      exit(1);
-    }
-  };
-
-  if (typePrefix == "i64[]")
-    return Param{ArrayParam<int64_t>{parseValues(toI64)}};
-  if (typePrefix == "f64[]")
-    return Param{ArrayParam<double>{parseValues(toF64)}};
-
-  // Scalars — must be exactly one value
-  if (valueStr.find(',') != std::string::npos) {
-    std::cerr << "Error: scalar param expects exactly one value, got: " << s
-              << "\n";
-    exit(1);
-  }
-
-  if (typePrefix == "i64")
-    return Param{ScalarParam<int64_t>{toI64(valueStr)}};
-  if (typePrefix == "f64")
-    return Param{ScalarParam<double>{toF64(valueStr)}};
-
-  std::cerr << "Error: unsupported param type '" << typePrefix
-            << "' (expected i64, i64[], f64, or f64[]), got: " << s << "\n";
-  exit(1);
-}
-
-static std::string readFile(std::string_view path) {
-  std::ifstream f(std::string(path), std::ios::binary);
-  if (!f) {
-    std::cerr << "Error: cannot open " << path << "\n";
-    exit(1);
-  }
-  std::ostringstream ss;
-  ss << f.rdbuf();
-  return ss.str();
-}
-
-int main(int argc, char **argv) {
+static int run(int argc, char **argv) {
   const char *ptxFile = nullptr;
   const char *kernelName = nullptr;
   std::vector<Param> params;
   Dims grid, block;
   int outputParam = 0;
-  int outputCount = -1; // -1 = all
+  std::optional<int> outputCount;
 
-  // Parse arguments
   for (int i = 1; i < argc; ++i) {
-    std::string_view arg = argv[i];
-    auto needsValue = [&](std::string_view opt) {
-      if (++i >= argc) {
-        std::cerr << "Error: " << opt << " requires a value\n";
-        exit(1);
-      }
+    std::string_view argument = argv[i];
+    auto needsValue = [&](std::string_view option) {
+      if (++i >= argc)
+        throw std::runtime_error(std::string(option) + " requires a value");
     };
-    if (arg == "--param") {
+    if (argument == "--param") {
       needsValue("--param");
       params.push_back(parseParam(argv[i]));
-    } else if (arg == "--grid") {
+    } else if (argument == "--grid") {
       needsValue("--grid");
       grid = parseDims(argv[i]);
-    } else if (arg == "--block") {
+    } else if (argument == "--block") {
       needsValue("--block");
       block = parseDims(argv[i]);
-    } else if (arg == "--output-param") {
+    } else if (argument == "--output-param") {
       needsValue("--output-param");
       outputParam = parseIntArg(argv[i], "--output-param");
-    } else if (arg == "--output-count") {
+    } else if (argument == "--output-count") {
       needsValue("--output-count");
       outputCount = parseIntArg(argv[i], "--output-count");
-    } else if (arg == "--kernel") {
+    } else if (argument == "--kernel") {
       needsValue("--kernel");
       kernelName = argv[i];
-    } else if (arg[0] == '-') {
-      std::cerr << "Error: unknown option " << arg << "\n";
-      exit(1);
+    } else if (!argument.empty() && argument.front() == '-') {
+      throw std::runtime_error("unknown option " + std::string(argument));
     } else {
       ptxFile = argv[i];
     }
@@ -259,89 +389,97 @@ int main(int argc, char **argv) {
                  "[--block X,Y,Z] [--output-param N] [--output-count N]\n";
     return 1;
   }
-
-  if (!kernelName) {
-    std::cerr << "Error: --kernel NAME is required\n";
-    return 1;
+  if (!kernelName)
+    throw std::runtime_error("--kernel NAME is required");
+  if (params.empty())
+    throw std::runtime_error("at least one --param is required");
+  if (outputParam < 0 || static_cast<size_t>(outputParam) >= params.size()) {
+    std::ostringstream message;
+    message << "output-param " << outputParam << " out of range (have "
+            << params.size() << " params)";
+    throw std::runtime_error(message.str());
   }
-
-  if (params.empty()) {
-    std::cerr << "Error: at least one --param is required\n";
-    return 1;
-  }
-
-  if (outputParam < 0 || outputParam >= static_cast<int>(params.size())) {
-    std::cerr << "Error: output-param " << outputParam << " out of range (have "
-              << params.size() << " params)\n";
-    return 1;
-  }
-
   if (isScalar(params[outputParam])) {
-    std::cerr << "Error: output-param " << outputParam
-              << " is a scalar (cannot read back)\n";
-    return 1;
+    std::ostringstream message;
+    message << "output-param " << outputParam
+            << " is a scalar (cannot read back)";
+    throw std::runtime_error(message.str());
   }
 
-  // Read PTX
-  std::string ptx = readFile(ptxFile);
+  size_t selectedArraySize = arraySize(params[outputParam]);
+  if (outputCount && *outputCount < 0)
+    throw std::runtime_error("--output-count must not be negative");
+  if (outputCount && static_cast<size_t>(*outputCount) > selectedArraySize) {
+    std::ostringstream message;
+    message << "--output-count " << *outputCount
+            << " exceeds selected output array size " << selectedArraySize;
+    throw std::runtime_error(message.str());
+  }
 
-  // Initialize CUDA
-  CHECK_CU(cuInit(0));
+#ifdef WARPFORTH_RUNNER_HOST_VALIDATION
+  std::cerr << "Error: CUDA execution unavailable in host-validation build\n";
+  return 2;
+#else
+  size_t count =
+      outputCount ? static_cast<size_t>(*outputCount) : selectedArraySize;
+  std::string ptx = readFile(ptxFile);
+  checkCu(cuInit(0), "cuInit");
 
   CUdevice device;
-  CHECK_CU(cuDeviceGet(&device, 0));
+  checkCu(cuDeviceGet(&device, 0), "cuDeviceGet");
+  CudaContext context = CudaContext::create(device);
+  CudaModule module = CudaModule::load(ptx.c_str());
 
-  CUcontext ctx;
-  CHECK_CU(cuCtxCreate(&ctx, 0, device));
+  CUfunction function;
+  checkCu(cuModuleGetFunction(&function, module.get(), kernelName),
+          "cuModuleGetFunction");
 
-  // Load PTX module
-  CUmodule module;
-  CHECK_CU(cuModuleLoadData(&module, ptx.c_str()));
-
-  CUfunction func;
-  CHECK_CU(cuModuleGetFunction(&func, module, kernelName));
-
-  // Allocate device buffers for array params
-  for (auto &p : params) {
-    if (auto *a = std::get_if<ArrayParam<int64_t>>(&p))
-      allocDevice(*a);
-    else if (auto *a = std::get_if<ArrayParam<double>>(&p))
-      allocDevice(*a);
+  std::vector<DeviceAllocation> allocations;
+  allocations.reserve(params.size());
+  std::vector<CUdeviceptr> devicePointers(params.size(), 0);
+  for (size_t i = 0; i < params.size(); ++i) {
+    if (auto *array = std::get_if<ArrayParam<int64_t>>(&params[i])) {
+      allocations.emplace_back(array->values.data(),
+                               array->values.size() * sizeof(int64_t));
+      devicePointers[i] = allocations.back().get();
+    } else if (auto *array = std::get_if<ArrayParam<double>>(&params[i])) {
+      allocations.emplace_back(array->values.data(),
+                               array->values.size() * sizeof(double));
+      devicePointers[i] = allocations.back().get();
+    }
   }
 
-  // Set up kernel parameters — Driver API expects array of pointers to args
-  std::vector<void *> kernelArgs(params.size());
-  for (size_t i = 0; i < params.size(); ++i)
-    kernelArgs[i] = kernelArgPtr(params[i]);
-
-  // Launch kernel
-  CHECK_CU(cuLaunchKernel(func, grid.x, grid.y, grid.z, block.x, block.y,
-                          block.z, 0, nullptr, kernelArgs.data(), nullptr));
-
-  CHECK_CU(cuCtxSynchronize());
-
-  // Copy back and print output param
-  size_t count = outputCount >= 0 ? static_cast<size_t>(outputCount) : 0;
-  if (auto *iArr = std::get_if<ArrayParam<int64_t>>(&params[outputParam])) {
-    if (outputCount < 0)
-      count = iArr->values.size();
-    printOutput(*iArr, count);
-  } else {
-    auto &fArr = std::get<ArrayParam<double>>(params[outputParam]);
-    if (outputCount < 0)
-      count = fArr.values.size();
-    printOutput(fArr, count);
+  std::vector<void *> kernelArguments(params.size());
+  for (size_t i = 0; i < params.size(); ++i) {
+    if (std::holds_alternative<ArrayParam<int64_t>>(params[i]) ||
+        std::holds_alternative<ArrayParam<double>>(params[i]))
+      kernelArguments[i] = &devicePointers[i];
+    else if (auto *scalar = std::get_if<ScalarParam<int64_t>>(&params[i]))
+      kernelArguments[i] = &scalar->value;
+    else
+      kernelArguments[i] = &std::get<ScalarParam<double>>(params[i]).value;
   }
 
-  // Cleanup — only free device memory for array params
-  for (auto &p : params) {
-    if (auto *a = std::get_if<ArrayParam<int64_t>>(&p))
-      cuMemFree(a->devicePtr);
-    else if (auto *a = std::get_if<ArrayParam<double>>(&p))
-      cuMemFree(a->devicePtr);
-  }
-  cuModuleUnload(module);
-  cuCtxDestroy(ctx);
+  checkCu(cuLaunchKernel(function, grid.x, grid.y, grid.z, block.x, block.y,
+                         block.z, 0, nullptr, kernelArguments.data(), nullptr),
+          "cuLaunchKernel");
+  checkCu(cuCtxSynchronize(), "cuCtxSynchronize");
 
+  CUdeviceptr outputPointer = devicePointers[outputParam];
+  if (auto *array = std::get_if<ArrayParam<int64_t>>(&params[outputParam]))
+    printOutput(*array, outputPointer, count);
+  else
+    printOutput(std::get<ArrayParam<double>>(params[outputParam]),
+                outputPointer, count);
   return 0;
+#endif
+}
+
+int main(int argc, char **argv) {
+  try {
+    return run(argc, argv);
+  } catch (const std::exception &error) {
+    std::cerr << "Error: " << error.what() << "\n";
+    return 1;
+  }
 }


### PR DESCRIPTION
## Summary
- reject negative or oversized output counts before output array access
- strictly parse complete integer and floating-point parameter tokens, including overflow and empty array fields
- manage CUDA contexts, modules, and device allocations with move-only RAII in correct teardown order
- exercise parsing and pre-CUDA validation through a host-only runner validation target

## Testing
- `cmake --build build --target format`
- `cmake --build build --target check-warpforth -j2` (110/110 passed)
- `cmake --build build --target check-clang-tidy`
- CUDA toolkit and GPU hardware are unavailable in the orb, so the CUDA-linked runner could not be compiled or executed; the host-validation target compiled and tests do not simulate CUDA success.