### PR TITLE
build(warpforthc): narrow MLIR dependencies

### DIFF
--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -12,6 +12,7 @@ add_mlir_library(MLIRConversionPasses
   MLIRGPUToNVVMTransforms
   MLIRGPUTransforms
   MLIRMathToLLVM
+  MLIRNVVMToLLVM
   MLIRReconcileUnrealizedCasts
   MLIRTransforms
 )

--- a/tools/warpforthc/CMakeLists.txt
+++ b/tools/warpforthc/CMakeLists.txt
@@ -1,8 +1,3 @@
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
-get_property(translation_libs GLOBAL PROPERTY MLIR_TRANSLATION_LIBS)
-
 add_llvm_executable(warpforthc
   warpforthc.cpp
 )
@@ -11,18 +6,19 @@ llvm_update_compile_flags(warpforthc)
 
 target_link_libraries(warpforthc
   PRIVATE
-  ${dialect_libs}
-  ${conversion_libs}
-  ${extension_libs}
-  ${translation_libs}
-  MLIRForth
   MLIRForthTranslation
   MLIRToPTXTranslation
   MLIRConversionPasses
-  MLIRForthToMemRefConversion
+  MLIRArithToLLVM
+  MLIRBuiltinToLLVMIRTranslation
+  MLIRControlFlowToLLVM
+  MLIRFuncToLLVM
+  MLIRGPUToLLVMIRTranslation
+  MLIRLLVMToLLVMIRTranslation
+  MLIRMemRefToLLVM
+  MLIRNVVMToLLVMIRTranslation
   MLIRNVVMTarget
   MLIRIR
-  MLIRParser
   MLIRPass
   MLIRSupport
 )

--- a/tools/warpforthc/warpforthc.cpp
+++ b/tools/warpforthc/warpforthc.cpp
@@ -4,14 +4,24 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
+#include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
+#include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/MLIRContext.h"
-#include "mlir/InitAllDialects.h"
-#include "mlir/InitAllExtensions.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassOptions.h"
-#include "mlir/Target/LLVMIR/Dialect/All.h"
+#include "mlir/Target/LLVM/NVVM/Target.h"
+#include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/GPU/GPUToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.h"
 #include "warpforth/Conversion/Passes.h"
 #include "warpforth/Dialect/Forth/ForthDialect.h"
 #include "warpforth/Translation/ForthToMLIR/ForthToMLIR.h"
@@ -52,10 +62,20 @@ int main(int argc, char **argv) {
 
   // Parse Forth source to MLIR
   DialectRegistry registry;
-  registerAllDialects(registry);
-  registerAllExtensions(registry);
-  registerAllToLLVMIRTranslations(registry);
-  registry.insert<forth::ForthDialect>();
+  registry
+      .insert<forth::ForthDialect, arith::ArithDialect, cf::ControlFlowDialect,
+              func::FuncDialect, memref::MemRefDialect>();
+
+  arith::registerConvertArithToLLVMInterface(registry);
+  cf::registerConvertControlFlowToLLVMInterface(registry);
+  registerConvertFuncToLLVMInterface(registry);
+  registerConvertMemRefToLLVMInterface(registry);
+
+  registerBuiltinDialectTranslation(registry);
+  registerGPUDialectTranslation(registry);
+  registerLLVMDialectTranslation(registry);
+  registerNVVMDialectTranslation(registry);
+  NVVM::registerNVVMTargetInterfaceExternalModels(registry);
 
   MLIRContext context(registry);
   SourceMgrDiagnosticHandler diagHandler(sourceMgr, &context);


### PR DESCRIPTION
## Summary

- register only the dialects and LLVM conversion interfaces required by the fixed Forth-to-PTX pipeline
- register the Builtin, GPU, LLVM, and NVVM translations plus the NVVM target model used for PTX serialization
- replace global MLIR linkage property lists with direct MLIR 20.1.8 targets and declare `MLIRNVVMToLLVM` on the pipeline library that uses it
- leave the broad registration in the general-purpose opt and translate drivers unchanged
- reduce the local `warpforthc` executable from 98,818,520 bytes to 24,973,888 bytes (74.7%) in the same build configuration

## Testing

- `cmake --build build`
- `cmake --build build --target format`
- `cmake --build build --target check-format`
- `cmake --build build --target warpforthc -j2`
- `build/bin/warpforthc test/Pipeline/full-pipeline.forth -o /tmp/warpforth-integer.ptx` (676-byte PTX, `.target sm_70`, visible `main` entry)
- `build/bin/warpforthc test/Pipeline/float-math-intrinsics.forth -o /tmp/warpforth-float.ptx` (5,419-byte PTX, `.target sm_70`, visible `main` entry)
- `cmake --build build --target check-warpforth -j2` (109/109 passed)
- `cmake --build build --target check-clang-tidy`