### PR TITLE
ci: run optional GPU tests via Vast.ai

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [canon]
   pull_request:
     branches: [canon]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
   LLVM_VERSION: "20"
@@ -60,3 +64,53 @@ jobs:
 
       - name: Test GPU infrastructure
         run: uv run pytest -q -m "not gpu"
+
+  gpu-test:
+    if: github.event_name == 'push'
+    needs: build-and-test
+    concurrency:
+      group: gpu-ci
+      cancel-in-progress: false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }} and MLIR
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_VERSION} main"
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang-${LLVM_VERSION} \
+            llvm-${LLVM_VERSION}-dev \
+            libmlir-${LLVM_VERSION}-dev \
+            mlir-${LLVM_VERSION}-tools
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Configure
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=clang-${LLVM_VERSION} \
+            -DCMAKE_CXX_COMPILER=clang++-${LLVM_VERSION} \
+            -DMLIR_DIR=/usr/lib/llvm-${LLVM_VERSION}/lib/cmake/mlir \
+            -DLLVM_DIR=/usr/lib/llvm-${LLVM_VERSION}/lib/cmake/llvm
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Run GPU tests on Vast.ai
+        env:
+          VASTAI_API_KEY: ${{ secrets.VASTAI_API_KEY }}
+        run: |
+          if [ -z "$VASTAI_API_KEY" ]; then
+            echo "VASTAI_API_KEY repository secret is not configured" >&2
+            exit 1
+          fi
+          uv run pytest -v -m gpu

--- a/.github/workflows/gpu-pr.yml
+++ b/.github/workflows/gpu-pr.yml
@@ -1,0 +1,88 @@
+name: GPU PR
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  LLVM_VERSION: "20"
+
+jobs:
+  authorize:
+    if: github.event.issue.pull_request && github.event.comment.body == '/gpu-test' && github.event.comment.author_association == 'OWNER'
+    runs-on: ubuntu-24.04
+    outputs:
+      head-sha: ${{ steps.pr.outputs.head-sha }}
+      same-repository: ${{ steps.pr.outputs.same-repository }}
+
+    steps:
+      - name: Resolve pull request head
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          head_repo=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')
+          head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')
+          echo "head-sha=${head_sha}" >> "$GITHUB_OUTPUT"
+          if [ "$head_repo" = "$GITHUB_REPOSITORY" ]; then
+            echo "same-repository=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "same-repository=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  gpu-test:
+    if: needs.authorize.outputs.same-repository == 'true'
+    needs: authorize
+    concurrency:
+      group: gpu-ci
+      cancel-in-progress: false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.authorize.outputs.head-sha }}
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }} and MLIR
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_VERSION} main"
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang-${LLVM_VERSION} \
+            llvm-${LLVM_VERSION}-dev \
+            libmlir-${LLVM_VERSION}-dev \
+            mlir-${LLVM_VERSION}-tools
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Configure
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=clang-${LLVM_VERSION} \
+            -DCMAKE_CXX_COMPILER=clang++-${LLVM_VERSION} \
+            -DMLIR_DIR=/usr/lib/llvm-${LLVM_VERSION}/lib/cmake/mlir \
+            -DLLVM_DIR=/usr/lib/llvm-${LLVM_VERSION}/lib/cmake/llvm
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Run GPU tests on Vast.ai
+        env:
+          VASTAI_API_KEY: ${{ secrets.VASTAI_API_KEY }}
+        run: |
+          if [ -z "$VASTAI_API_KEY" ]; then
+            echo "VASTAI_API_KEY repository secret is not configured" >&2
+            exit 1
+          fi
+          uv run pytest -v -m gpu


### PR DESCRIPTION
## Summary

- add a GPU test job to the existing CI workflow
- run GPU tests automatically after ordinary CI passes on pushes to `canon`
- keep GPU testing optional on PR events; repository users with write access can manually dispatch CI against a repository-hosted PR branch
- use the `GPU CI` environment's `VASTAI_API_KEY` secret
- serialize paid GPU jobs and cap each job at 45 minutes
- fail clearly if the environment secret is missing instead of silently skipping

## Validation

- `actionlint .github/workflows/ci.yml`
- `uv run pytest -q -m "not gpu"` (8 passed, 37 deselected)
- `uv run pytest -m gpu --collect-only -q` (37 tests collected)
- `uv run ruff check gpu_test/`
- `uv run ruff format --check gpu_test/`
- `cmake --build build --target warpforthc -j2`