### PR TITLE
docs: add Review MLIR skill

### DIFF
--- a/.agents/skills/review-mlir/SKILL.md
+++ b/.agents/skills/review-mlir/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: review-mlir
+description: Reviews C++ and TableGen changes for idiomatic, version-appropriate MLIR usage and existing upstream functionality. Use when reviewing MLIR dialects, operations, rewrites, conversions, passes, analyses, parsers, printers, or translations.
+---
+
+# Review MLIR
+
+Review MLIR code against the codebase's actual LLVM/MLIR revision. Find correctness issues first, then opportunities to replace custom machinery with supported MLIR or LLVM facilities.
+
+## Review Contract
+
+- Treat "modern" as idiomatic for the revision the codebase builds against, not automatically LLVM `main`.
+- Verify API availability before recommending it. Do not propose an API from a newer release without identifying the compatibility constraint.
+- Prefer the narrowest upstream abstraction that expresses the required semantics. Do not recommend replacement merely because an API has a similar name.
+- Preserve semantics and intentional compatibility surfaces. Do not require incidental behavior, implementation quirks, or exact printed-IR formatting to remain unchanged when idiomatic MLIR can simplify them.
+- Identify observable changes introduced by a cleanup and distinguish harmless canonicalization or presentation changes from semantic or compatibility changes that require a deliberate decision.
+- Report only actionable findings supported by code or upstream documentation/source. Separate definite defects from optional improvements.
+- Avoid broad style churn, speculative abstraction, and migration advice unrelated to the reviewed change.
+
+## Workflow
+
+### 1. Establish the compatibility baseline
+
+Determine the LLVM/MLIR revision before judging API usage. Inspect, in order of relevance:
+
+1. Dependency lockfiles, submodules, package manifests, toolchain files, and CI images.
+2. CMake configuration and `find_package(MLIR ...)` constraints.
+3. `llvm-config --version`, MLIR CMake package metadata, or installed headers when the build environment is authoritative.
+4. Existing code patterns only as secondary evidence; they may themselves be legacy.
+
+State the detected revision or release in the review. If it cannot be established, explicitly mark version-sensitive advice as conditional.
+
+### 2. Understand the change in context
+
+Read the complete diff and enough surrounding code to establish:
+
+- the owning dialect, pass, conversion, analysis, or translation boundary;
+- operation invariants and expected input/output IR;
+- pass pipeline ordering and legality assumptions;
+- whether textual IR, bytecode, generated APIs, or downstream users form an intentional compatibility surface rather than merely exposing incidental current behavior;
+- tests that define current behavior.
+
+Trace referenced helpers and generated definitions. Do not infer an operation's contract from one call site.
+
+### 3. Search for existing functionality
+
+For each nontrivial custom helper or algorithm introduced by the change, formulate the semantic job it performs, then search in this order:
+
+1. Existing helpers and conventions in the local codebase.
+2. The pinned MLIR and LLVM headers, sources, tests, and examples available locally.
+3. Official documentation for the pinned release.
+4. Upstream LLVM source and history when local sources are absent or when checking deprecation/replacement history.
+
+Search by semantics as well as names. Check likely facilities including:
+
+- operation traits, interfaces, declarative assembly formats, builders, folders, canonicalizers, and verifiers;
+- `PatternRewriter`, rewrite patterns, dialect conversion, type converters, legality, and materializations;
+- `OpBuilder`, `ImplicitLocOpBuilder`, `IRMapping`, `TypeSwitch`, symbol-table utilities, walk APIs, and region/block utilities;
+- pass infrastructure, analyses, data-flow frameworks, transform infrastructure, and dialect interfaces;
+- LLVM ADTs, casting, ranges, scope-exit, error handling, and debug facilities.
+
+Confirm that an upstream facility satisfies the required semantics. Check ownership, mutation behavior, traversal order, failure behavior, diagnostics, location propagation, and asymptotic cost, but do not preserve differences that are incidental to the custom implementation. Document any meaningful behavior that the replacement intentionally changes.
+
+### 4. Review MLIR invariants
+
+Use [the detailed checklist](reference/review-checklist.md) selectively. Prioritize checks relevant to the changed code rather than mechanically commenting on every category.
+
+Pay particular attention to:
+
+- IR mutation through the correct rewriter and preservation of use-def, dominance, isolation, and symbol invariants;
+- safe iteration when operations, blocks, or regions may be erased or replaced;
+- precise pattern match failure with no mutation before a successful match is established;
+- conversion legality and type-conversion materializations at every boundary;
+- operation verification, parser/printer round trips, generated accessor use, and diagnostic quality;
+- pass state, analysis invalidation, multithreading assumptions, and deterministic output.
+
+### 5. Validate findings
+
+Use the repository's documented build and test entry points. Prefer the smallest decisive checks first:
+
+- compile the affected target to catch generated-API and version mismatches;
+- run focused `lit` or unit tests for the changed pass/dialect;
+- run parser/printer round-trip, verifier-negative, and pass-pipeline tests when applicable;
+- run broader checks only when the blast radius warrants them.
+
+When recommending an upstream API, verify it by inspecting its declaration and at least one representative upstream use or test for the pinned revision. A search-result name alone is insufficient evidence.
+
+## Finding Format
+
+Order findings by severity. For each finding provide:
+
+1. **Severity and location** — exact file and line or changed construct.
+2. **Observed issue** — what the current code does.
+3. **Why it matters** — concrete failure mode, maintenance cost, or missed invariant.
+4. **Recommended change** — smallest correct fix or upstream facility.
+5. **Evidence** — relevant API declaration, upstream example/test, or executed check; include version applicability.
+
+Use these categories:
+
+- **Correctness**: can produce invalid IR, miscompile, crash, lose diagnostics, or violate a pass contract.
+- **Compatibility**: uses an unavailable/deprecated API or unintentionally changes IR/API compatibility.
+- **Idiomatic MLIR**: duplicates a supported abstraction or bypasses framework lifecycle/invariants.
+- **Optional simplification**: cleanup with a clear payoff whose semantic and compatibility effects are understood, even if incidental output or implementation behavior changes.
+
+If no actionable findings remain, say so directly and list the revision checked and validation performed. Do not invent low-value comments to fill the review.
+
+## Applying Fixes
+
+When asked to fix findings:
+
+1. Preserve required semantics and intentional compatibility surfaces when replacing custom code with an upstream facility; simplify incidental behavior rather than recreating it.
+2. Make intentional observable changes explicit and update brittle tests that encode incidental formatting or implementation details.
+3. Add or adjust tests for the invariant that exposed the issue, not for implementation details.
+4. Format changed C++ or TableGen using the repository's configured formatter.

--- a/.agents/skills/review-mlir/reference/review-checklist.md
+++ b/.agents/skills/review-mlir/reference/review-checklist.md
@@ -1,0 +1,99 @@
+# MLIR Review Checklist
+
+Use only the sections relevant to the change. This checklist supplements direct reasoning; it is not a substitute for understanding the IR contract.
+
+## Operations and ODS
+
+- Could a trait or interface express and verify a structural invariant now implemented manually?
+- Are arguments, results, regions, successors, properties, and attributes represented declaratively where practical?
+- Does the operation use generated typed accessors instead of string-based attribute lookup or positional operand/result access where generated APIs exist?
+- Are builders minimal and unambiguous? Do inferred result types use an inference interface when appropriate?
+- Is custom parsing/printing necessary, or can declarative assembly format express the syntax?
+- If custom assembly is needed, does it round-trip all semantic state, handle optional/default values appropriately, and emit useful parse errors? Do not require incidental whitespace, ordering, or spelling choices to remain identical unless they are a declared compatibility surface.
+- Are verifier checks split appropriately between structural verification and region verification? Do diagnostics identify the violated invariant and relevant value/type?
+- Are fold and canonicalization rules terminating, semantics-preserving, and placed on the operation that owns the invariant?
+- Do traits such as purity, memory effects, speculatability, commutativity, and terminator/successor traits accurately describe behavior?
+
+## Builders, Locations, and Diagnostics
+
+- Is the insertion point explicit and valid, including for nested region construction?
+- Would `ImplicitLocOpBuilder` reduce repeated locations without hiding meaningful source locations?
+- Are source locations preserved or fused rather than replaced with unknown locations?
+- Are diagnostics emitted through the operation/context facilities and attached to the most relevant operation or location?
+- Are expected non-matches returned as failure rather than emitted as errors?
+- Are unchecked casts and `getDefiningOp` assumptions justified by verified invariants?
+
+## Rewrites and Canonicalization
+
+- Does all mutation occur through the provided rewriter when running inside a rewrite framework?
+- Is the IR left untouched when `match` fails? If mutation is needed during matching, is it transactional or deferred?
+- Are in-place modifications wrapped with the rewriter's modification protocol?
+- Are replacements type-compatible, and are all result uses handled deliberately?
+- Is erasure safe with respect to remaining uses and iteration invalidation?
+- Can the pattern reapply forever or increase IR without a bounded-recursion declaration and proof?
+- Is pattern benefit meaningful, or is correctness accidentally dependent on application order?
+- Would a fold, declarative rewrite, interface, or canonicalization pattern be a smaller ownership boundary?
+
+## Dialect Conversion and Type Conversion
+
+- Are legal and illegal dialects/operations/types specified precisely enough that conversion cannot silently leave unsupported IR?
+- Is dynamic legality based on the post-conversion invariant rather than merely operation names?
+- Does each pattern convert operands, results, region arguments, successor operands, and nested signatures that cross the boundary?
+- Are source, target, and argument materializations defined only where genuinely needed and guaranteed to be reconciled?
+- Are signature conversion and region type conversion performed with framework utilities rather than manual block surgery?
+- Is one-to-many type conversion handled by facilities available in the pinned revision instead of ad hoc packing?
+- Does partial versus full conversion match the pass contract?
+- Are unrealized conversion casts reconciled, and do tests ensure none leak unexpectedly?
+
+## Regions, Blocks, Symbols, and SSA
+
+- Are block arguments, terminators, successors, and region kinds valid after every transformation?
+- Is dominance preserved when moving or cloning operations? Is `IRMapping` used for cloning/remapping SSA values and blocks?
+- Are operation walks safe when callbacks erase, replace, or move visited operations?
+- Are symbol lookup and mutation performed with symbol-table APIs, respecting visibility, nesting, and `IsolatedFromAbove`?
+- Are symbol references updated when symbols are renamed or moved?
+- Is region isolation respected when capturing values or creating nested operations?
+
+## Passes and Analyses
+
+- Does the pass operate at the narrowest appropriate operation type?
+- Is mutable per-run state local or reset, so a pass instance is safe under pass-manager reuse and multithreading?
+- Are dependent dialects declared, and are pass options/statistics/debug output registered through pass infrastructure?
+- Are analyses requested rather than recomputed manually? Are preserved analyses declared only when truly preserved?
+- Does failure call `signalPassFailure()` after emitting a useful diagnostic?
+- Is traversal deterministic where output order is observable?
+- Does the pass avoid global mutable state and context mutation during parallel execution?
+- Are pipeline prerequisites explicit rather than accidental assumptions about earlier passes?
+
+## Types, Attributes, and Storage
+
+- Are types and attributes uniqued through the context rather than manually allocated or cached?
+- Are storage keys complete, immutable, and consistent between equality and construction?
+- Is mutable storage actually required and synchronized according to MLIR's context rules?
+- Are parse/print/verify hooks consistent and round-trip tested?
+- Could a builtin type/attribute, data-layout query, or existing dialect interface replace custom representation logic?
+
+## Interfaces and Effects
+
+- Would an operation, dialect, type, or attribute interface decouple behavior from concrete operation-name switches?
+- Are external models appropriate when behavior belongs to a consumer rather than the defining dialect?
+- Are memory effects complete enough for dead-code elimination, scheduling, and alias-sensitive transforms?
+- Are side-effect-free or speculatable claims valid for all operands, attributes, and nested regions?
+- Is callability, branch behavior, region control flow, or loop behavior modeled through the corresponding interface when consumers need it?
+
+## Performance and Ownership
+
+- Is there repeated IR scanning where an analysis, symbol table, dominance structure, or listener can provide the information?
+- Are expensive objects and analyses reused within their valid lifetime without stale caches?
+- Are `SmallVector`, `ArrayRef`, `MutableArrayRef`, ranges, and `DenseMap`/`DenseSet` used with valid lifetimes and suitable ownership?
+- Do callbacks capture values with sufficient lifetime, especially in deferred rewrite or pass-pipeline construction?
+- Does a proposed upstream replacement preserve complexity and memory behavior on large IR?
+
+## Testing
+
+- Is there a positive test for the intended transformation and focused negative tests for rejected forms?
+- Do verifier tests use expected diagnostics and test malformed IR at the correct abstraction boundary?
+- Do transformation tests check semantic structure rather than incidental SSA names or unstable printing details?
+- Is custom syntax round-trip tested for semantic equivalence rather than byte-for-byte reproduction?
+- Are type-conversion boundaries, regions, symbols, and multi-result cases represented?
+- Is test coverage pinned to behavior rather than a private helper implementation?


### PR DESCRIPTION
## Summary

- add a general-purpose Review MLIR skill for reviewing C++ and TableGen code
- require recommendations to match the codebase's pinned LLVM/MLIR revision
- guide reviewers to find and verify existing upstream functionality before retaining custom machinery
- include a focused checklist for ODS, rewrites, conversions, passes, SSA, interfaces, performance, and tests
- preserve semantic and intentional compatibility surfaces while allowing incidental printing and implementation details to be simplified

## Validation

- `git diff --check`
- reloaded workspace skills and confirmed `review-mlir` is discovered without errors
- confirmed the skill contains no project-specific references