### PR TITLE
ci: show manual GPU tests on PRs

### DIFF
--- a/.github/workflows/gpu-pr.yml
+++ b/.github/workflows/gpu-pr.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  statuses: write
 
 env:
   LLVM_VERSION: "20"
@@ -45,6 +46,17 @@ jobs:
     timeout-minutes: 45
 
     steps:
+      - name: Mark GPU tests as running on the PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head-sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state=pending \
+            -f context='GPU tests' \
+            -f target_url="$RUN_URL"
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.authorize.outputs.head-sha }}
@@ -86,3 +98,16 @@ jobs:
             exit 1
           fi
           uv run pytest -v -m gpu
+
+      - name: Report GPU test result on the PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head-sha }}
+          STATE: ${{ job.status == 'success' && 'success' || 'failure' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state="$STATE" \
+            -f context='GPU tests' \
+            -f target_url="$RUN_URL"


### PR DESCRIPTION
## Summary

- publish a pending GPU test status on the PR head when `/gpu-test` starts
- publish the final result with a link to the Actions run

## Validation

- `actionlint .github/workflows/gpu-pr.yml`
- `git diff --check HEAD^ HEAD`